### PR TITLE
feat: fetcher retry + timeout (#13)

### DIFF
--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -1,0 +1,106 @@
+import { createLogger } from './logger.js';
+
+const log = createLogger('Retry');
+
+export interface RetryOptions {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  isRetryable?: (error: unknown) => boolean;
+}
+
+function defaultIsRetryable(error: unknown): boolean {
+  // TypeError usually indicates DNS/connection failure
+  if (error instanceof TypeError) return true;
+
+  if (error instanceof FetchError) {
+    // 429 Too Many Requests
+    if (error.status === 429) return true;
+    // 5xx Server Errors
+    if (error.status >= 500 && error.status <= 599) return true;
+    // Client errors (except 429) are not retryable
+    return false;
+  }
+
+  // AbortError from timeout
+  if (error instanceof DOMException && error.name === 'AbortError') return true;
+
+  return false;
+}
+
+function jitter(baseMs: number): number {
+  // ±25% jitter
+  const factor = 0.75 + Math.random() * 0.5;
+  return Math.round(baseMs * factor);
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts: RetryOptions = {},
+): Promise<T> {
+  const maxRetries = opts.maxRetries ?? 3;
+  const initialDelayMs = opts.initialDelayMs ?? 1000;
+  const isRetryable = opts.isRetryable ?? defaultIsRetryable;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt >= maxRetries || !isRetryable(error)) {
+        throw error;
+      }
+
+      let delayMs: number;
+
+      // Respect Retry-After header if present
+      if (error instanceof FetchError && error.retryAfter != null) {
+        delayMs = error.retryAfter * 1000;
+      } else {
+        delayMs = jitter(initialDelayMs * Math.pow(2, attempt));
+      }
+
+      log.warn('Retrying after error', {
+        attempt: attempt + 1,
+        maxRetries,
+        delayMs,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError;
+}
+
+export class FetchError extends Error {
+  constructor(
+    message: string,
+    public readonly url: string,
+    public readonly status: number,
+    public readonly retryAfter?: number,
+  ) {
+    super(message);
+    this.name = 'FetchError';
+  }
+}
+
+export function parseRetryAfter(header: string | null): number | undefined {
+  if (!header) return undefined;
+
+  // Try parsing as seconds (integer)
+  const seconds = parseInt(header, 10);
+  if (!isNaN(seconds) && seconds >= 0) return seconds;
+
+  // Try parsing as HTTP-date
+  const date = Date.parse(header);
+  if (!isNaN(date)) {
+    const delaySec = Math.max(0, Math.ceil((date - Date.now()) / 1000));
+    return delaySec;
+  }
+
+  return undefined;
+}

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { withRetry, FetchError, parseRetryAfter } from '../src/lib/retry.js';
+import { setLogLevel } from '../src/lib/logger.js';
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    setLogLevel('error'); // suppress retry logs in tests
+  });
+
+  afterEach(() => {
+    setLogLevel('info');
+  });
+
+  it('returns result on first success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const result = await withRetry(fn);
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 503 and succeeds', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new FetchError('503', 'http://x', 503))
+      .mockResolvedValue('recovered');
+
+    const result = await withRetry(fn, { initialDelayMs: 10 });
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on 404 (non-retryable)', async () => {
+    const fn = vi.fn()
+      .mockRejectedValue(new FetchError('404', 'http://x', 404));
+
+    await expect(withRetry(fn, { initialDelayMs: 10 })).rejects.toThrow('404');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 429 with Retry-After', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new FetchError('429', 'http://x', 429, 1))
+      .mockResolvedValue('ok');
+
+    const start = Date.now();
+    const result = await withRetry(fn, { initialDelayMs: 10 });
+    const elapsed = Date.now() - start;
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+    // Retry-After is 1 second, so delay should be ~1000ms
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+  });
+
+  it('throws after max retries exceeded', async () => {
+    const fn = vi.fn()
+      .mockRejectedValue(new FetchError('500', 'http://x', 500));
+
+    await expect(withRetry(fn, { maxRetries: 2, initialDelayMs: 10 }))
+      .rejects.toThrow('500');
+    expect(fn).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  it('retries on TypeError (DNS/connection error)', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValue('ok');
+
+    const result = await withRetry(fn, { initialDelayMs: 10 });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('FetchError', () => {
+  it('has correct properties', () => {
+    const err = new FetchError('test', 'http://example.com', 503, 5);
+    expect(err.name).toBe('FetchError');
+    expect(err.url).toBe('http://example.com');
+    expect(err.status).toBe(503);
+    expect(err.retryAfter).toBe(5);
+    expect(err.message).toBe('test');
+  });
+});
+
+describe('parseRetryAfter', () => {
+  it('parses integer seconds', () => {
+    expect(parseRetryAfter('120')).toBe(120);
+    expect(parseRetryAfter('0')).toBe(0);
+  });
+
+  it('returns undefined for null', () => {
+    expect(parseRetryAfter(null)).toBeUndefined();
+  });
+
+  it('parses HTTP-date format', () => {
+    const futureDate = new Date(Date.now() + 60_000).toUTCString();
+    const result = parseRetryAfter(futureDate);
+    expect(result).toBeDefined();
+    expect(result).toBeGreaterThanOrEqual(55);
+    expect(result).toBeLessThanOrEqual(65);
+  });
+
+  it('returns 0 for past HTTP-date', () => {
+    const pastDate = new Date(Date.now() - 60_000).toUTCString();
+    expect(parseRetryAfter(pastDate)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/lib/retry.ts` with `withRetry()`, `FetchError`, `parseRetryAfter()`
- Exponential backoff with ±25% jitter, max 3 retries
- Retryable: 429, 5xx, TypeError (DNS/connection), AbortError (timeout)
- `AbortSignal.timeout(30s)` on all fetch requests
- `Retry-After` header support (integer seconds + HTTP-date)
- 11 tests in `tests/retry.test.ts`

Closes #13

## Test plan
- [x] All 86 tests pass (75 existing + 11 new)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)