### PR TITLE
feat: disk cache for fetched content (#15)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ const log = createLogger('CLI');
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DB_DIR = resolve(__dirname, '../data');
 const DB_PATH = resolve(DB_DIR, 'langspec.db');
+const CACHE_DIR = resolve(DB_DIR, 'cache');
 
 const SUPPORTED_LANGUAGES = getSupportedLanguages();
 
@@ -42,7 +43,7 @@ async function main(): Promise<void> {
         const db = initializeDatabase(DB_PATH);
         try {
           for (const lang of SUPPORTED_LANGUAGES) {
-            await ingestSpec(db, lang);
+            await ingestSpec(db, lang, CACHE_DIR);
           }
         } finally {
           db.close();
@@ -60,7 +61,7 @@ async function main(): Promise<void> {
       mkdirSync(DB_DIR, { recursive: true });
       const db = initializeDatabase(DB_PATH);
       try {
-        await ingestSpec(db, language);
+        await ingestSpec(db, language, CACHE_DIR);
       } finally {
         db.close();
       }

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { createLogger } from './logger.js';
+
+const log = createLogger('Cache');
+
+export interface CacheMeta {
+  url: string;
+  etag: string | null;
+  fetchedAt: string;
+}
+
+export class DiskCache {
+  constructor(private readonly baseDir: string) {}
+
+  private dirFor(language: string, doc: string): string {
+    return join(this.baseDir, language, doc);
+  }
+
+  private keyFor(url: string): string {
+    return createHash('sha256').update(url).digest('hex').substring(0, 16);
+  }
+
+  has(language: string, doc: string, url: string): boolean {
+    const dir = this.dirFor(language, doc);
+    const key = this.keyFor(url);
+    return existsSync(join(dir, `${key}.meta.json`));
+  }
+
+  getMeta(language: string, doc: string, url: string): CacheMeta | null {
+    const dir = this.dirFor(language, doc);
+    const key = this.keyFor(url);
+    const metaPath = join(dir, `${key}.meta.json`);
+    if (!existsSync(metaPath)) return null;
+    try {
+      return JSON.parse(readFileSync(metaPath, 'utf-8')) as CacheMeta;
+    } catch {
+      return null;
+    }
+  }
+
+  getContent(language: string, doc: string, url: string): string | null {
+    const dir = this.dirFor(language, doc);
+    const key = this.keyFor(url);
+    const contentPath = join(dir, `${key}.html`);
+    if (!existsSync(contentPath)) return null;
+    try {
+      return readFileSync(contentPath, 'utf-8');
+    } catch {
+      return null;
+    }
+  }
+
+  put(language: string, doc: string, url: string, content: string, etag: string | null): void {
+    const dir = this.dirFor(language, doc);
+    mkdirSync(dir, { recursive: true });
+    const key = this.keyFor(url);
+
+    writeFileSync(join(dir, `${key}.html`), content, 'utf-8');
+
+    const meta: CacheMeta = {
+      url,
+      etag,
+      fetchedAt: new Date().toISOString(),
+    };
+    writeFileSync(join(dir, `${key}.meta.json`), JSON.stringify(meta, null, 2), 'utf-8');
+
+    log.debug('Cached', { language, doc, url: url.substring(0, 80) });
+  }
+}

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DiskCache } from '../src/lib/cache.js';
+import { setLogLevel } from '../src/lib/logger.js';
+
+describe('DiskCache', () => {
+  let tempDir: string;
+  let cache: DiskCache;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'langspec-cache-test-'));
+    cache = new DiskCache(tempDir);
+    setLogLevel('error');
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    setLogLevel('info');
+  });
+
+  it('put and getContent round-trip', () => {
+    const content = '<h2>Test</h2><p>Hello world</p>';
+    cache.put('go', 'go-spec', 'https://go.dev/ref/spec', content, '"etag123"');
+
+    const retrieved = cache.getContent('go', 'go-spec', 'https://go.dev/ref/spec');
+    expect(retrieved).toBe(content);
+  });
+
+  it('put and getMeta round-trip', () => {
+    cache.put('rust', 'rust-reference', 'https://example.com/intro.md', 'content', '"abc"');
+
+    const meta = cache.getMeta('rust', 'rust-reference', 'https://example.com/intro.md');
+    expect(meta).not.toBeNull();
+    expect(meta!.url).toBe('https://example.com/intro.md');
+    expect(meta!.etag).toBe('"abc"');
+    expect(meta!.fetchedAt).toBeDefined();
+  });
+
+  it('has returns false for uncached URLs', () => {
+    expect(cache.has('go', 'go-spec', 'https://not-cached.com')).toBe(false);
+  });
+
+  it('has returns true for cached URLs', () => {
+    cache.put('go', 'go-spec', 'https://go.dev/ref/spec', 'data', null);
+    expect(cache.has('go', 'go-spec', 'https://go.dev/ref/spec')).toBe(true);
+  });
+
+  it('cache key is deterministic for the same URL', () => {
+    const url = 'https://example.com/page.html';
+    cache.put('java', 'jls', url, 'content1', '"e1"');
+
+    // Overwrite with same URL
+    cache.put('java', 'jls', url, 'content2', '"e2"');
+
+    const retrieved = cache.getContent('java', 'jls', url);
+    expect(retrieved).toBe('content2');
+
+    const meta = cache.getMeta('java', 'jls', url);
+    expect(meta!.etag).toBe('"e2"');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `src/lib/cache.ts` with `DiskCache` class: `has()`, `getMeta()`, `getContent()`, `put()`
- Cache structure: `data/cache/{lang}/{doc}/{url-sha256-16hex}.html` + `.meta.json`
- Fetcher strategies check cache ETag via `If-None-Match`, serve from cache on 304
- Save new content to cache on 200 response
- `CACHE_DIR` constant added to CLI entry point
- 5 tests in `tests/cache.test.ts`

Closes #15

## Test plan
- [x] All 95 tests pass (90 existing + 5 new)
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)