### PR TITLE
docs: architecture documentation for langspec-mcp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,17 @@ src/
 - 429 受信時にバッチ内の `delayMs` を動的に増加
 - `Retry-After` ヘッダー値を使用、無ければ倍増（上限 10 秒）
 
+## Documentation
+`docs/` にアーキテクチャ解説ドキュメント（日本語）を格納。初心者向けに設計〜実装を7章構成で解説。
+- `docs/README.md` — 目次・読み方ガイド・全体図
+- `docs/01-overview.md` — MCP概要と2つのコマンド
+- `docs/02-typescript-basics.md` — TS プロジェクト構成・ビルド
+- `docs/03-config.md` — 言語設定レジストリ・FetchStrategy
+- `docs/04-ingestion-pipeline.md` — 取り込みパイプライン全工程
+- `docs/05-database.md` — SQLite + FTS5 設計
+- `docs/06-mcp-server.md` — MCPサーバ・ツール実装
+- `docs/07-reliability.md` — ログ・リトライ・キャッシュ・レート制限
+
 ## Build & Run
 ```bash
 npm run build                              # TypeScript compile

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -1,0 +1,122 @@
+# 01: 全体像 — MCPとこのサーバの目的
+
+## このドキュメントで学ぶこと
+
+- MCPプロトコルとは何か
+- langspec-mcp が解決する問題
+- 2つのコマンド（`ingest` と `serve`）の役割
+- プロジェクト全体の構成
+
+## MCPプロトコルとは何か
+
+**MCP (Model Context Protocol)** は、AIアシスタント（Claude Desktopなど）が外部のツールやデータにアクセスするための標準プロトコルです。
+
+通常、AIは学習時のデータしか知りません。しかしMCPを使うと、AIが「ツール」を呼び出して、リアルタイムのデータを取得したり、外部システムを操作したりできるようになります。
+
+```
+┌───────────────────┐          ┌───────────────────┐
+│   Claude Desktop  │  JSON-RPC │   MCP Server      │
+│                   │<========>│  (langspec-mcp)    │
+│  「Goのスライスに  │  stdin/   │                   │
+│   ついて教えて」   │  stdout   │  SQLite DB から    │
+│                   │          │  仕様書を検索       │
+└───────────────────┘          └───────────────────┘
+```
+
+MCPの仕組みはシンプルです:
+
+1. AIが「どんなツールがあるか？」と聞く → サーバがツール一覧を返す
+2. AIがツールを呼ぶ（例: `search_spec("slice types", "go")`）
+3. サーバがDBを検索し、結果をAIに返す
+4. AIがその結果を使って回答を組み立てる
+
+## langspec-mcp が解決する問題
+
+AIは言語仕様について質問されたとき、学習データから「なんとなく」回答します。しかし:
+
+- 仕様書の正確な文面を引用できない
+- どのバージョンの仕様かわからない
+- 仕様書のどのセクションに書いてあるかリンクを示せない
+
+langspec-mcp は、プログラミング言語の公式仕様書をデータベースに取り込み、AIが正確に検索・引用できるようにします。
+
+## 2つのコマンド
+
+### `ingest` — 仕様書をデータベースに取り込む
+
+```
+npm run ingest -- --language go
+```
+
+このコマンドは以下の処理を行います:
+
+```
+インターネット上の仕様書
+        │
+        v
+  ┌─────────────┐
+  │  ダウンロード │  fetcher.ts
+  │  (HTTP取得)   │
+  └──────┬──────┘
+         v
+  ┌─────────────┐
+  │  解析        │  parser.ts
+  │  (HTML/MD→   │
+  │   セクション) │
+  └──────┬──────┘
+         v
+  ┌─────────────┐
+  │  正規化      │  normalizer.ts
+  │  (URL,hash)  │
+  └──────┬──────┘
+         v
+  ┌─────────────┐
+  │  DB保存      │  ingestion/index.ts
+  │  (SQLite)    │
+  └─────────────┘
+```
+
+### `serve` — MCPサーバを起動する
+
+```
+npm run serve
+```
+
+起動すると、標準入力（stdin）と標準出力（stdout）を使って JSON-RPC で通信します。Claude Desktop の設定ファイルにこのサーバを登録すると、AIが自動的にツールを認識して使えるようになります。
+
+## 対応コード
+
+エントリーポイントは `src/index.ts` です。`main()` 関数内の `switch` 文で `ingest` と `serve` を切り替えています:
+
+```typescript
+// src/index.ts:36-78
+switch (command) {
+  case 'ingest': {
+    // --language フラグを解析し、仕様書を取り込む
+    const language = parseLanguageFlag(process.argv.slice(3));
+    // ...
+    await ingestSpec(db, language, CACHE_DIR);
+    break;
+  }
+
+  case 'serve': {
+    // MCPサーバを起動（stdin/stdoutで待ち受け）
+    const db = initializeDatabase(DB_PATH);
+    await startServer(db);
+    break;
+  }
+}
+```
+
+- **データベースファイル**: `data/langspec.db`
+- **キャッシュディレクトリ**: `data/cache/`
+
+どちらも `data/` ディレクトリに配置され、`.gitignore` で管理対象外になっています。
+
+## まとめ
+
+- MCPは、AIが外部ツールと会話するための標準プロトコル
+- langspec-mcp は仕様書をDBに取り込み（`ingest`）、AIに検索ツールを提供する（`serve`）
+- 通信はstdin/stdout上のJSON-RPCで行われる
+
+次のドキュメント [02-typescript-basics.md](./02-typescript-basics.md) では、このプロジェクトのTypeScript構成を解説します。

--- a/docs/02-typescript-basics.md
+++ b/docs/02-typescript-basics.md
@@ -1,0 +1,183 @@
+# 02: TypeScript プロジェクトの仕組み
+
+## このドキュメントで学ぶこと
+
+- `package.json` の役割と主要フィールドの意味
+- `tsconfig.json` の設定とその理由
+- TypeScript のビルドの流れ
+- ES Modules と `"type": "module"` の意味
+- なぜインポートに `.js` 拡張子を書くのか
+
+## package.json — プロジェクトの設計図
+
+`package.json` はNode.jsプロジェクトの中心ファイルです。プロジェクト名、使用するライブラリ、実行コマンドなどを定義します。
+
+### dependencies と devDependencies
+
+```json
+// package.json:26-37
+"dependencies": {
+  "@modelcontextprotocol/sdk": "^1.26.0",
+  "better-sqlite3": "^11.8.1",
+  "cheerio": "^1.0.0",
+  "zod": "^3.24.1"
+},
+"devDependencies": {
+  "@types/better-sqlite3": "^7.6.12",
+  "@types/node": "^22.10.5",
+  "typescript": "^5.7.2",
+  "vitest": "^4.0.18"
+}
+```
+
+| 区分 | 説明 | 例 |
+|------|------|-----|
+| **dependencies** | 実行時に必要なライブラリ | MCP SDK, SQLite, cheerio, zod |
+| **devDependencies** | 開発時のみ必要なライブラリ | TypeScript コンパイラ, 型定義, テストツール |
+
+`npm install` を実行すると、両方がインストールされます。本番デプロイ時には `npm install --production` で dependencies だけをインストールできます。
+
+### npm scripts
+
+```json
+// package.json:11-17
+"scripts": {
+  "build": "tsc",
+  "dev": "tsc --watch",
+  "ingest": "node dist/index.js ingest",
+  "serve": "node dist/index.js serve",
+  "test": "vitest run",
+  "test:watch": "vitest"
+}
+```
+
+| コマンド | 実行されるもの | 説明 |
+|---------|-------------|------|
+| `npm run build` | `tsc` | TypeScript → JavaScript にコンパイル |
+| `npm run dev` | `tsc --watch` | ファイル変更を検知して自動コンパイル |
+| `npm run ingest` | `node dist/index.js ingest` | コンパイル済みJSで取り込み実行 |
+| `npm run serve` | `node dist/index.js serve` | コンパイル済みJSでサーバ起動 |
+| `npm test` | `vitest run` | テストを1回実行 |
+
+ポイント: `npm run ingest` は `dist/index.js` を実行しています。`src/index.ts` ではありません。TypeScript ファイルは直接実行できず、まずコンパイルが必要です。
+
+## tsconfig.json — TypeScript コンパイラの設定
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}
+```
+
+重要な設定を順番に解説します:
+
+### `"target": "ES2022"`
+
+コンパイル後のJavaScriptがどのバージョンの文法を使うかを指定します。ES2022 は `Array.at()` や `Object.hasOwn()` などのモダンな機能を含みます。Node.js 18以上で動作します。
+
+### `"module": "Node16"` と `"moduleResolution": "Node16"`
+
+**これが最も初心者がつまずくポイントです。**
+
+Node.js には2つのモジュールシステムがあります:
+
+```
+CommonJS (古い方式):           ES Modules (新しい方式):
+const fs = require('fs');     import fs from 'node:fs';
+module.exports = { ... };     export function foo() { ... }
+```
+
+このプロジェクトは ES Modules を使っています。`"module": "Node16"` は「Node.js 16以降のES Modulesルールに従え」という意味です。
+
+### なぜインポートに `.js` を書くのか？
+
+```typescript
+// src/index.ts:6-10
+import { initializeDatabase } from './db/schema.js';    // ← .js!
+import { ingestSpec } from './ingestion/index.js';       // ← .js!
+import { startServer } from './server.js';               // ← .js!
+```
+
+ソースコードは `.ts` ファイルなのに、インポートパスには `.js` と書きます。これは一見おかしく見えますが、理由があります:
+
+```
+コンパイル前:                      コンパイル後:
+src/db/schema.ts         ──tsc──>  dist/db/schema.js
+src/index.ts             ──tsc──>  dist/index.js
+  import from './db/schema.js'       import from './db/schema.js'
+  （.jsのまま出力される）              （実際に.jsファイルがある → OK!）
+```
+
+TypeScript コンパイラ（tsc）は **インポートパスを書き換えません**。だから、コンパイル後に実際に存在するファイル名（`.js`）をあらかじめ書いておく必要があるのです。
+
+### `"outDir": "./dist"` と `"rootDir": "./src"`
+
+```
+コンパイル前:              コンパイル後:
+src/                      dist/
+├── index.ts       ──>    ├── index.js
+├── server.ts      ──>    ├── server.js
+├── db/            ──>    ├── db/
+│   └── schema.ts  ──>    │   └── schema.js
+└── ...            ──>    └── ...
+```
+
+`src/` 内の `.ts` ファイルが `dist/` 内の `.js` ファイルに変換されます。ディレクトリ構造はそのまま維持されます。
+
+## `"type": "module"` の意味
+
+```json
+// package.json:5
+"type": "module"
+```
+
+この1行が package.json にあると、Node.js はプロジェクト内の `.js` ファイルをすべて ES Modules として扱います。これがないと CommonJS として扱われ、`import`/`export` 構文が使えません。
+
+## ビルドの流れ まとめ
+
+```
+1. npm run build を実行
+        │
+        v
+2. tsc（TypeScriptコンパイラ）が起動
+        │
+        v
+3. tsconfig.json を読み込み
+   - src/ 内の全 .ts ファイルを対象
+   - 型チェックを実行（strict: true）
+        │
+        v
+4. 問題なければ dist/ に .js ファイルを出力
+   - .js       : 実行可能なJavaScript
+   - .d.ts     : 型定義ファイル（ライブラリとして使う場合用）
+   - .js.map   : ソースマップ（デバッグ時にTSの行番号を表示）
+        │
+        v
+5. node dist/index.js で実行可能に
+```
+
+## まとめ
+
+- `package.json` はプロジェクトの設計図。ライブラリとスクリプトを管理する
+- TypeScript は直接実行できない。`tsc` でコンパイルしてから `node` で実行する
+- `"module": "Node16"` + `"type": "module"` で ES Modules を使用
+- インポートに `.js` を書くのは、コンパイル後のファイル名に合わせるため
+
+次のドキュメント [03-config.md](./03-config.md) では、言語設定の仕組みを解説します。

--- a/docs/03-config.md
+++ b/docs/03-config.md
@@ -1,0 +1,256 @@
+# 03: 言語設定レジストリ
+
+## このドキュメントで学ぶこと
+
+- `LanguageConfig` と `DocConfig` の構造
+- 3つの取得戦略（FetchStrategy）の違い
+- `sourcePolicy` による著作権保護の仕組み
+- 新しい言語を追加する方法
+
+## 設定レジストリとは
+
+このプロジェクトは複数のプログラミング言語の仕様書を扱います。しかし、言語ごとに仕様書の公開形式が異なります:
+
+- Go: 1ページのHTMLに全仕様が載っている
+- Java: 目次ページ + 複数の章ページに分かれている
+- Rust: GitHubリポジトリにMarkdownファイルが並んでいる
+
+これらの違いを吸収するために、各言語の設定を1つの配列 `LANGUAGES` に集約しています。
+
+**対応コード**: `src/config/languages.ts`
+
+## データ構造
+
+### LanguageConfig — 言語の定義
+
+```typescript
+// src/config/languages.ts:24-28
+interface LanguageConfig {
+  language: string;       // 内部キー（例: 'go', 'java'）
+  displayName: string;    // 表示名（例: 'Go', 'Java'）
+  docs: DocConfig[];      // この言語に属するドキュメント群
+}
+```
+
+1つの言語に複数のドキュメントを持たせることができます（例: 言語仕様 + 標準ライブラリ）。現在は各言語に1つずつです。
+
+### DocConfig — ドキュメントの定義
+
+```typescript
+// src/config/languages.ts:3-22
+interface DocConfig {
+  doc: string;                // ドキュメント識別子（例: 'go-spec'）
+  displayName: string;        // 表示名
+  fetchStrategy: FetchStrategy; // 取得方法（後述）
+  sourcePolicy: 'excerpt_only' | 'local_fulltext_ok';
+  headingSelectors?: string;  // HTMLで使う見出しセレクタ
+  notes?: string;             // 補足メモ
+
+  // single-html / multi-html-toc 用
+  url?: string;               // ページURL
+  indexUrl?: string;          // 目次ページURL
+  chapterPattern?: RegExp;    // 章リンクの正規表現パターン
+
+  // github-markdown 用
+  githubOwner?: string;       // GitHubオーナー
+  githubRepo?: string;        // リポジトリ名
+  githubPath?: string;        // ファイルパス
+  manifestFile?: string;      // マニフェストファイル（例: SUMMARY.md）
+  canonicalBaseUrl?: string;  // 正規化URLのベース
+}
+```
+
+## 3つの取得戦略（FetchStrategy）
+
+```typescript
+// src/config/languages.ts:1
+type FetchStrategy = 'single-html' | 'multi-html-toc' | 'github-markdown';
+```
+
+### 1. `single-html` — 1ページHTML
+
+```
+  1回のHTTPリクエスト
+         │
+         v
+  ┌──────────────┐
+  │ https://go.  │     ← 全仕様が1ページに収まっている
+  │ dev/ref/spec │
+  │              │
+  │ h2: Types    │
+  │ h3: Array    │
+  │ h3: Slice    │
+  │ h2: ...      │
+  └──────────────┘
+```
+
+**使用言語**: Go
+
+最もシンプルな戦略です。1つのURLにアクセスするだけで仕様書全体が手に入ります。
+
+```typescript
+// src/config/languages.ts:32-44 (Go の設定)
+{
+  language: 'go',
+  displayName: 'Go',
+  docs: [{
+    doc: 'go-spec',
+    displayName: 'The Go Programming Language Specification',
+    fetchStrategy: 'single-html',
+    url: 'https://go.dev/ref/spec',
+    headingSelectors: 'h2, h3, h4',
+    sourcePolicy: 'excerpt_only',
+    canonicalBaseUrl: 'https://go.dev/ref/spec',
+  }],
+}
+```
+
+### 2. `multi-html-toc` — 目次 + 複数章
+
+```
+  目次ページ取得          各章を順次取得
+       │                   │
+       v                   v
+  ┌──────────┐    ┌───┐ ┌───┐ ┌───┐
+  │ index.html│──> │ch1│ │ch2│ │ch3│ ...
+  │           │    │   │ │   │ │   │
+  │ - ch1     │    └───┘ └───┘ └───┘
+  │ - ch2     │      19章分を順番に取得
+  │ - ch3     │      (200ms間隔で礼儀正しく)
+  │ - ...     │
+  └──────────┘
+```
+
+**使用言語**: Java (JLS)
+
+まず目次ページ（`index.html`）を取得し、そこからリンクを抽出して各章を順次ダウンロードします。サーバに負荷をかけないよう、リクエスト間に遅延（200ms）を入れています。
+
+```typescript
+// src/config/languages.ts:48-59 (Java の設定)
+{
+  language: 'java',
+  displayName: 'Java',
+  docs: [{
+    doc: 'jls',
+    displayName: 'The Java Language Specification (SE21)',
+    fetchStrategy: 'multi-html-toc',
+    indexUrl: 'https://docs.oracle.com/javase/specs/jls/se21/html/index.html',
+    headingSelectors: 'h2, h3, h4',
+    sourcePolicy: 'excerpt_only',
+    canonicalBaseUrl: 'https://docs.oracle.com/javase/specs/jls/se21/html',
+  }],
+}
+```
+
+### 3. `github-markdown` — GitHubリポジトリのMarkdown
+
+```
+  SUMMARY.md取得         各.mdファイルを順次取得
+       │                      │
+       v                      v
+  ┌──────────┐    ┌─────┐ ┌─────┐ ┌─────┐
+  │SUMMARY.md│──> │ch1.md│ │ch2.md│ │ch3.md│ ...
+  │          │    │      │ │      │ │      │
+  │ - [ch1]  │    └──────┘ └──────┘ └──────┘
+  │ - [ch2]  │     raw.githubusercontent.com
+  │ - [ch3]  │     から取得
+  └──────────┘
+```
+
+**使用言語**: Rust, TypeScript
+
+GitHubリポジトリ内のMarkdownファイル群を取得します。Rustは `SUMMARY.md`（マニフェストファイル）からファイル一覧を取得し、TypeScriptはGitHub APIでディレクトリ内容を取得します。
+
+```typescript
+// src/config/languages.ts:63-77 (Rust の設定)
+{
+  language: 'rust',
+  displayName: 'Rust',
+  docs: [{
+    doc: 'rust-reference',
+    displayName: 'The Rust Reference',
+    fetchStrategy: 'github-markdown',
+    githubOwner: 'rust-lang',
+    githubRepo: 'reference',
+    githubPath: 'src',
+    manifestFile: 'SUMMARY.md',
+    sourcePolicy: 'local_fulltext_ok',
+    canonicalBaseUrl: 'https://doc.rust-lang.org/reference',
+  }],
+}
+```
+
+## sourcePolicy — 著作権保護
+
+```typescript
+sourcePolicy: 'excerpt_only' | 'local_fulltext_ok'
+```
+
+| ポリシー | 意味 | 対象 |
+|---------|------|------|
+| `excerpt_only` | 抜粋（最初の1200文字）のみ提供 | Go, Java（著作権保護） |
+| `local_fulltext_ok` | 全文を提供可能 | Rust, TypeScript（オープンソース） |
+
+Go や Java の仕様書は著作権で保護されているため、AIに全文を渡すことは避け、抜粋と公式サイトへのリンクを提供します。Rust や TypeScript のドキュメントはオープンソースライセンスなので全文提供が可能です。
+
+この値は `get_section` ツールで使われます（`src/tools/get-section.ts:28`）:
+
+```typescript
+const fulltextAvailable = section.source_policy === 'local_fulltext_ok';
+// fulltext_available が false なら excerpt のみ返す
+```
+
+## 新しい言語を追加する方法
+
+新しい言語を追加するには、`src/config/languages.ts` の `LANGUAGES` 配列に1つエントリを追加するだけです。
+
+例えば Python を追加する場合:
+
+```typescript
+{
+  language: 'python',
+  displayName: 'Python',
+  docs: [{
+    doc: 'python-reference',
+    displayName: 'The Python Language Reference',
+    fetchStrategy: 'single-html',
+    url: 'https://docs.python.org/3/reference/index.html',
+    headingSelectors: 'h1, h2, h3',
+    sourcePolicy: 'excerpt_only',
+    canonicalBaseUrl: 'https://docs.python.org/3/reference',
+  }],
+}
+```
+
+追加後は:
+
+```bash
+npm run build                         # TypeScriptを再コンパイル
+npm run ingest -- --language python    # 新言語を取り込み
+```
+
+これだけで、MCPサーバの `list_languages` ツールに新しい言語が表示され、`search_spec` で検索できるようになります。コードの他の部分を変更する必要はありません。
+
+## ユーティリティ関数
+
+`src/config/languages.ts` は設定データだけでなく、それを参照するための関数も提供します:
+
+```typescript
+// src/config/languages.ts:102-128
+getLanguageConfig('go')       // → LanguageConfig（言語全体の設定）
+getDocConfig('go')            // → DocConfig（最初のドキュメント設定）
+getDocConfig('go', 'go-spec') // → DocConfig（特定ドキュメント）
+getSupportedLanguages()       // → ['go', 'java', 'rust', 'typescript']
+getAllLanguageConfigs()        // → LanguageConfig[] (全設定)
+```
+
+`getSupportedLanguages()` は MCP ツールの `enum` として使われ、AIが「どの言語を指定できるか」を知るための情報源になります（`src/server.ts:31`）。
+
+## まとめ
+
+- 言語設定は `LANGUAGES` 配列に集約されている
+- 3つの取得戦略で異なる形式の仕様書に対応
+- `sourcePolicy` で著作権保護レベルを制御
+- 新しい言語の追加は配列に1エントリ追加するだけ
+
+次のドキュメント [04-ingestion-pipeline.md](./04-ingestion-pipeline.md) では、データ取り込みパイプラインの詳細を解説します。

--- a/docs/04-ingestion-pipeline.md
+++ b/docs/04-ingestion-pipeline.md
@@ -1,0 +1,416 @@
+# 04: データ取り込みパイプライン
+
+## このドキュメントで学ぶこと
+
+- 仕様書を取り込む5ステップの全体像
+- ダウンロード処理（3つの戦略の具体的な動作）
+- HTML/Markdown の解析とセクション分割のロジック
+- 正規化（URL構築、ハッシュ生成）
+- DB保存と差分検出の仕組み
+
+## パイプライン全体図
+
+`npm run ingest -- --language go` を実行すると、以下の5ステップが順番に実行されます:
+
+```
+Step 1: ダウンロード (fetcher.ts)
+  │  インターネットから仕様書をHTTPで取得
+  │  戦略に応じて1ページ or 複数ページ
+  v
+Step 2: 解析 (parser.ts)
+  │  HTML/Markdownを読み込み、
+  │  見出しごとにセクションに分割
+  v
+Step 3: 正規化 (normalizer.ts)
+  │  正規URL構築、抜粋作成、
+  │  コンテンツハッシュ計算
+  v
+Step 4: DB保存 (ingestion/index.ts)
+  │  トランザクション内でupsert、
+  │  差分検出（inserted/updated/unchanged）
+  v
+Step 5: レポート
+     何件挿入/更新/変更なしかをログ出力
+```
+
+オーケストレーター（指揮者）の役割を果たすのが `src/ingestion/index.ts` の `ingestSpec()` 関数です。
+
+## Step 1: ダウンロード — `fetcher.ts`
+
+**対応コード**: `src/ingestion/fetcher.ts`
+
+### エントリーポイント: `fetchSpec()`
+
+```typescript
+// src/ingestion/fetcher.ts:271-288
+export async function fetchSpec(config: DocConfig, opts: FetchSpecOptions = {}): Promise<FetchOutcome> {
+  switch (config.fetchStrategy) {
+    case 'single-html':
+      return fetchSingleHtml(config, opts.snapshotEtag, ctx);
+    case 'multi-html-toc':
+      return fetchMultiHtmlToc(config, ctx);
+    case 'github-markdown':
+      return fetchGithubMarkdown(config, ctx);
+  }
+}
+```
+
+設定の `fetchStrategy` に応じて、3つの取得関数を使い分けます。
+
+### `fetchSingleHtml()` — 1回のHTTPリクエスト
+
+```
+  fetchUrl('https://go.dev/ref/spec')
+       │
+       v
+  200 OK → HTML本文 + ETag を返す
+  304 Not Modified → キャッシュから返す（変更なし）
+```
+
+最もシンプルです。1つのURLに対して `fetch()` を呼ぶだけです。ETag（ファイルの「指紋」のようなもの）を使って、前回から変更がなければダウンロードをスキップします。
+
+### `fetchMultiHtmlToc()` — 目次から章を抽出
+
+```typescript
+// src/ingestion/fetcher.ts:133-183 の流れ
+// 1. 目次ページを取得
+const { body: indexHtml } = await fetchUrl(indexUrl);
+
+// 2. cheerioでHTMLを解析し、章のリンクを抽出
+const $ = load(indexHtml!);
+$('a[href]').each((_, elem) => {
+  const href = $(elem).attr('href');
+  if (href && /^jls-\d+\.html$/.test(href)) {
+    chapterLinks.push(href);
+  }
+});
+
+// 3. 各章を順次取得（200ms間隔）
+for (const link of chapterLinks) {
+  const result = await fetchWithCache(chapterUrl, ctx);
+  results.push(result);
+  await delay(delayMs);  // サーバに優しく
+}
+```
+
+Java JLS の場合、`index.html` から `jls-1.html`, `jls-2.html`, ... のリンクを正規表現で抽出し、順番にダウンロードします。
+
+### `fetchGithubMarkdown()` — GitHubからMarkdownファイル群を取得
+
+```typescript
+// src/ingestion/fetcher.ts:203-263 の流れ
+// 1. SUMMARY.md（マニフェスト）を取得してファイル一覧を解析
+//    または GitHub API でディレクトリ一覧を取得
+const { body: manifest } = await fetchUrl(manifestUrl);
+mdFiles = parseSummaryMd(manifest!, basePath);
+
+// 2. 各Markdownファイルを順次取得（100ms間隔）
+for (const filePath of mdFiles) {
+  const fileUrl = `${rawBase}/${filePath}`;
+  const result = await fetchWithCache(fileUrl, ctx);
+  results.push(result);
+  await delay(delayMs);
+}
+```
+
+`raw.githubusercontent.com` からMarkdownファイルの生テキストを取得します。
+
+### `FetchOutcome` パターン — 部分失敗への対応
+
+すべての取得関数は `FetchOutcome` 型を返します:
+
+```typescript
+// src/types.ts:59-68
+interface FetchOutcome {
+  results: FetchResult[];   // 成功したページ群
+  errors: FetchError[];     // 失敗したページ群
+  summary: {
+    total: number;          // 全ページ数
+    fetched: number;        // 新規取得した数
+    cached: number;         // キャッシュから取得した数
+    failed: number;         // 失敗した数
+  };
+}
+```
+
+複数ページを取得する際、一部のページが失敗しても残りは処理を続けます。全ページが失敗した場合のみエラーをスローします。
+
+```
+20ページ中 18ページ成功、2ページ失敗
+→ 18ページ分は正常に処理。失敗分はログに警告を出力。
+→ サーバの一時的な問題なら、次回 ingest で自動復旧。
+```
+
+## Step 2: 解析 — `parser.ts`
+
+**対応コード**: `src/ingestion/parser.ts`
+
+ダウンロードしたHTML/Markdownを読み込み、見出しごとに「セクション」に分割します。
+
+### HTMLパーサ: `parseHtmlSpec()`
+
+cheerio（jQueryライクなHTMLパーサ）を使ってDOMとして読み込みます。
+
+```typescript
+// src/ingestion/parser.ts:18-79 の概要
+export function parseHtmlSpec(html: string, config: DocConfig, pageUrl?: string): ParsedSection[] {
+  const $ = load(html);
+  const headings = $(fullSelector);  // h2, h3, h4 を抽出
+
+  headings.each((i, elem) => {
+    const title = $heading.text().trim();
+
+    // 見出しの後から次の見出しまでの内容を本文として取得
+    let $next = $heading.next();
+    while ($next.length > 0) {
+      // 次の見出しに到達したら終了
+      if (nextTag && selectors.some(s => ...)) break;
+      contentParts.push($next.text().trim());
+      $next = $next.next();
+    }
+
+    sections.push({
+      section_id: sectionId,
+      title,
+      section_path: sectionPath,  // 階層パス
+      content: contentParts.join('\n\n'),
+    });
+  });
+}
+```
+
+動作イメージ:
+
+```html
+<h2 id="Types">Types</h2>
+<p>A type determines a set of values...</p>
+
+<h3 id="Array_types">Array types</h3>
+<p>An array is a numbered sequence...</p>
+
+<h3 id="Slice_types">Slice types</h3>
+<p>A slice is a descriptor...</p>
+```
+
+↓ 解析結果:
+
+```
+セクション1: { id: "Types",       path: "Types",                  content: "A type determines..." }
+セクション2: { id: "Array_types", path: "Types > Array types",    content: "An array is..." }
+セクション3: { id: "Slice_types", path: "Types > Slice types",    content: "A slice is..." }
+```
+
+### 階層パス（section_path）の構築
+
+見出しレベル（h2, h3, h4）を使って、パンくず式の階層パスを構築します:
+
+```
+pathStack の変化:
+
+h2 "Types"       → pathStack: [{level:2, title:"Types"}]
+                   → path: "Types"
+
+h3 "Array types" → pathStack: [{level:2, title:"Types"}, {level:3, title:"Array types"}]
+                   → path: "Types > Array types"
+
+h3 "Slice types" → pop(level>=3), push
+                   pathStack: [{level:2, title:"Types"}, {level:3, title:"Slice types"}]
+                   → path: "Types > Slice types"
+
+h2 "Statements"  → pop(level>=2), push
+                   pathStack: [{level:2, title:"Statements"}]
+                   → path: "Statements"
+```
+
+### Section ID の安定化
+
+セクションIDはURLのアンカー（`#Types`）として使われるため、安定している必要があります。
+
+```typescript
+// src/ingestion/parser.ts:44
+const sectionId = $heading.attr('id') || stableId(baseUrl, title, i);
+```
+
+1. HTMLの見出しに `id` 属性がある → そのまま使用（例: `id="Types"`）
+2. `id` 属性がない → `stableId()` でSHA-256ハッシュから生成（例: `gen-a3b2c1d4e5f6`）
+
+```typescript
+// src/ingestion/parser.ts:9-12
+function stableId(baseUrl: string, headingText: string, index: number): string {
+  const input = `${baseUrl}|${headingText}|${index}`;
+  return 'gen-' + createHash('sha256').update(input).digest('hex').substring(0, 12);
+}
+```
+
+### Markdownパーサ: `parseMarkdownSpec()`
+
+Markdownの場合は `#` で始まる行を見出しとして検出します。
+
+```typescript
+// src/ingestion/parser.ts:128-225 の概要
+// 1. フロントマター（---で囲まれたメタデータ）を解析
+const { frontMatter, body } = parseFrontMatter(markdown);
+
+// 2. Twoslash記法（TypeScript Handbook特有）を除去
+const cleaned = stripTwoslash(body);
+
+// 3. 各行を走査
+for (const line of lines) {
+  const headingMatch = line.match(/^(#{1,4})\s+(.+)$/);
+  if (headingMatch) {
+    // 前のセクションを確定
+    flushSection();
+    // 新しいセクションを開始
+    currentTitle = headingMatch[2].trim();
+    currentLevel = headingMatch[1].length;  // # の数 = レベル
+  } else {
+    currentContent.push(line);
+  }
+}
+```
+
+フェンスドコードブロック（`` ``` `` で囲まれた部分）の中にある `#` は見出しとして扱わないよう、追跡しています:
+
+```typescript
+// src/ingestion/parser.ts:164-167
+if (/^(`{3,}|~{3,})/.test(line)) {
+  inFencedBlock = !inFencedBlock;  // コードブロックの開始/終了を切り替え
+}
+```
+
+## Step 3: 正規化 — `normalizer.ts`
+
+**対応コード**: `src/ingestion/normalizer.ts`
+
+解析されたセクションに、DB保存に必要な情報を付加します。
+
+```typescript
+// src/ingestion/normalizer.ts:4-39
+export function normalizeSections(sections: ParsedSection[], meta: { ... }): NormalizedSection[] {
+  return sections.map(s => {
+    const fulltext = s.content;
+
+    // 1. 抜粋: 最初の1200文字を切り出し
+    const excerpt = fulltext.length > EXCERPT_MAX_LENGTH
+      ? fulltext.substring(0, EXCERPT_MAX_LENGTH) + '...'
+      : fulltext;
+
+    // 2. 正規URL: 戦略に応じた組み立て
+    const canonicalUrl = buildCanonicalUrl(meta.baseUrl, s.section_id, s.pageUrl, meta.pageUrlPrefix);
+
+    // 3. コンテンツハッシュ: SHA-256で変更検出用
+    const content_hash = hashContent(fulltext);
+
+    return { ...fields, excerpt, canonicalUrl, content_hash, source_policy };
+  });
+}
+```
+
+### 正規URL の構築
+
+戦略によってURLの組み立て方が異なります:
+
+```typescript
+// src/ingestion/normalizer.ts:41-64
+function buildCanonicalUrl(baseUrl, sectionId, pageUrl, pageUrlPrefix): string {
+  if (!pageUrl) {
+    // single-html: https://go.dev/ref/spec#Types
+    return `${baseUrl}#${sectionId}`;
+  }
+  if (pageUrl.startsWith('http')) {
+    // multi-html-toc: https://docs.oracle.com/.../jls-4.html#Types
+    return `${pageUrl}#${sectionId}`;
+  }
+  // github-markdown: https://doc.rust-lang.org/reference/types.html#array-types
+  return `${baseUrl}/${pageName}.html#${sectionId}`;
+}
+```
+
+### コンテンツハッシュ
+
+```typescript
+// src/db/schema.ts:104-106
+export function hashContent(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+```
+
+内容のSHA-256ハッシュを計算します。次回の `ingest` 時にこのハッシュを比較し、内容が変わっていなければ更新をスキップできます。
+
+## Step 4: DB保存 — `ingestion/index.ts`
+
+**対応コード**: `src/ingestion/index.ts`
+
+### オーケストレーター: `ingestSpec()`
+
+```typescript
+// src/ingestion/index.ts:14-100 の流れ
+export async function ingestSpec(db: Database.Database, language: string, cacheDir?: string): Promise<void> {
+  const docConfig = getDocConfig(language);
+  const queries = new DatabaseQueries(db);
+  const version = `snapshot-${yyyymmdd}`;  // 例: snapshot-20260208
+
+  // 1. 前回のETagを取得（条件付きリクエスト用）
+  const previousSnapshot = queries.getLatestSnapshot(language, docConfig.doc);
+
+  // 2. ダウンロード
+  const outcome = await fetchSpec(docConfig, { snapshotEtag, cache, language });
+
+  // 3. 全ページ304なら処理終了（変更なし）
+  if (allUnchanged) return;
+
+  // 4. 解析 + 正規化
+  for (const result of outcome.results) {
+    if (result.status === 304) continue;  // 変更なしページはスキップ
+    const parsed = parseSpec(result.html, docConfig, result.pageUrl);
+    const normalized = normalizeSections(parsed, { ... });
+    allNormalized.push(...normalized);
+  }
+
+  // 5. トランザクション内でDB保存
+  const transaction = db.transaction(() => {
+    queries.upsertSnapshot({ ... });
+    for (const section of allNormalized) {
+      const result = queries.upsertSection(section);
+      counters[result]++;  // inserted / updated / unchanged
+    }
+  });
+  transaction();
+}
+```
+
+### 差分検出の仕組み
+
+`upsertSection()` はハッシュを比較して、3つの結果を返します:
+
+```typescript
+// src/db/queries.ts:53-84
+upsertSection(s): UpsertResult {
+  const existingHash = this.getSectionHash(s.language, s.doc, s.version, s.section_id);
+
+  if (existingHash === s.content_hash) {
+    return 'unchanged';  // ハッシュ同一 → スキップ
+  }
+
+  // INSERT ... ON CONFLICT DO UPDATE
+  this.db.prepare(`...`).run(...);
+
+  return existingHash === undefined ? 'inserted' : 'updated';
+}
+```
+
+```
+初回 ingest:   全セクションが 'inserted'  → "162 inserted, 0 updated, 0 unchanged"
+2回目 ingest:  変更なし → "0 inserted, 0 updated, 162 unchanged"
+仕様更新後:    一部変更 → "0 inserted, 3 updated, 159 unchanged"
+```
+
+## まとめ
+
+- パイプラインは「取得 → 解析 → 正規化 → 保存」の4ステップ
+- 取得戦略は3種類あり、言語設定で切り替える
+- HTMLは cheerio でDOM解析、Markdownは行ベースで見出し検出
+- 正規化でURL構築とハッシュ計算を行う
+- 差分検出により、変更のないセクションの無駄な更新を避ける
+
+次のドキュメント [05-database.md](./05-database.md) では、SQLiteデータベースの設計を詳しく解説します。

--- a/docs/05-database.md
+++ b/docs/05-database.md
@@ -1,0 +1,250 @@
+# 05: SQLite + FTS5 データベース設計
+
+## このドキュメントで学ぶこと
+
+- SQLiteを選んだ理由
+- テーブル設計（snapshots, sections, fts_sections）
+- FTS5全文検索インデックスの仕組み
+- トリガーによるインデックス自動同期
+- マイグレーション（スキーマバージョン管理）
+
+## なぜSQLiteか
+
+| 比較項目 | SQLite | PostgreSQL/MySQL |
+|---------|--------|-----------------|
+| セットアップ | 不要（ファイル1つ） | サーバのインストール・起動が必要 |
+| 運用 | なし | バックアップ、監視、アップデート |
+| 適した規模 | 個人〜小規模 | 中〜大規模 |
+| 全文検索 | FTS5（組み込み） | 別途設定が必要 |
+
+langspec-mcp は個人の開発マシン上で動くツールです。データベースサーバを別途立てる必要がなく、`data/langspec.db` という1つのファイルだけで完結するSQLiteが最適です。
+
+## テーブル設計
+
+```
+┌──────────────┐       ┌──────────────────┐       ┌─────────────────┐
+│  snapshots   │       │    sections      │       │  fts_sections   │
+│──────────────│       │──────────────────│       │  (FTS5仮想TBL)  │
+│ id           │       │ id               │       │─────────────────│
+│ language     │       │ language         │──────>│ rowid (=id)     │
+│ doc          │       │ doc              │       │ title           │
+│ version      │       │ version          │       │ section_path    │
+│ fetched_at   │       │ section_id       │       │ content         │
+│ etag         │       │ title            │       └─────────────────┘
+│ source_url   │       │ section_path     │           FTS5が自動的に
+└──────────────┘       │ canonical_url    │           転置インデックスを
+  いつ取得したか         │ excerpt          │           構築・管理
+                       │ fulltext         │
+                       │ content_hash     │
+                       │ source_policy    │
+                       └──────────────────┘
+```
+
+**対応コード**: `src/db/schema.ts`
+
+### `snapshots` テーブル — 取得メタデータ
+
+```sql
+-- src/db/schema.ts:39-48
+CREATE TABLE snapshots (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  language TEXT NOT NULL,          -- 言語キー（例: 'go'）
+  doc TEXT NOT NULL,               -- ドキュメントキー（例: 'go-spec'）
+  version TEXT NOT NULL,           -- バージョン（例: 'snapshot-20260208'）
+  fetched_at TEXT NOT NULL,        -- 取得日時（ISO 8601）
+  etag TEXT,                       -- HTTPレスポンスのETag
+  source_url TEXT NOT NULL,        -- 取得元URL
+  UNIQUE(language, doc, version)   -- 同じ言語・文書・バージョンは1件のみ
+);
+```
+
+「いつ」「どの言語の」「どのバージョンを」取得したかを記録します。ETagを保存することで、次回の `ingest` 時に条件付きリクエスト（`If-None-Match`）が可能になります。
+
+### `sections` テーブル — セクションデータ
+
+```sql
+-- src/db/schema.ts:53-67
+CREATE TABLE sections (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  language TEXT NOT NULL,          -- 言語キー
+  doc TEXT NOT NULL,               -- ドキュメントキー
+  version TEXT NOT NULL,           -- バージョン
+  section_id TEXT NOT NULL,        -- セクション識別子（URLアンカー用）
+  title TEXT NOT NULL,             -- セクションタイトル
+  section_path TEXT NOT NULL,      -- 階層パス（例: 'Types > Array types'）
+  canonical_url TEXT NOT NULL,     -- 公式サイトへのリンク
+  excerpt TEXT NOT NULL,           -- 抜粋（最大1200文字）
+  fulltext TEXT NOT NULL,          -- 全文
+  content_hash TEXT NOT NULL,      -- SHA-256ハッシュ（差分検出用）
+  source_policy TEXT NOT NULL DEFAULT 'excerpt_only',
+  UNIQUE(language, doc, version, section_id)
+);
+```
+
+仕様書の各セクション（見出しとその内容）を1行として保存します。約2,300行（4言語合計）のデータが格納されています。
+
+### `fts_sections` — FTS5全文検索インデックス
+
+```sql
+-- src/db/schema.ts:72-78
+CREATE VIRTUAL TABLE fts_sections USING fts5(
+  title,                      -- セクションタイトルを検索対象に
+  section_path,               -- 階層パスを検索対象に
+  content,                    -- 本文を検索対象に
+  content='sections',         -- データ本体は sections テーブル
+  content_rowid='id',         -- sections.id と紐付け
+  tokenize='porter unicode61' -- トークナイザ（後述）
+);
+```
+
+## FTS5 の仕組み
+
+FTS5 (Full-Text Search 5) は SQLite に組み込まれた全文検索エンジンです。
+
+### 通常のSQLとFTS5の違い
+
+```sql
+-- 通常のSQL: LIKE検索（遅い、部分一致のみ）
+SELECT * FROM sections WHERE fulltext LIKE '%slice%';
+
+-- FTS5: 全文検索（高速、語幹マッチング対応）
+SELECT * FROM fts_sections WHERE fts_sections MATCH 'slice';
+```
+
+### content-sync モード
+
+`content='sections'` を指定すると、FTS5は「インデックスだけ」を管理します。実際のデータは `sections` テーブルに置かれます。
+
+```
+sections テーブル:                fts_sections (FTS5):
+┌──────────────────────┐         ┌──────────────────────┐
+│ id=1, title="Types", │         │ 転置インデックス:     │
+│ fulltext="A type..." │────────>│  "type" → [1, 3, 5]  │
+├──────────────────────┤         │  "array" → [2]       │
+│ id=2, title="Array", │────────>│  "slice" → [3]       │
+│ fulltext="An array.."│         │  ...                 │
+└──────────────────────┘         └──────────────────────┘
+  実データ                         検索用インデックスのみ
+```
+
+メリット: データの重複を避け、ストレージを節約できます。
+
+注意: このモードでは FTS5 の `snippet()` 関数が使えません。そのため、スニペット抽出は自前で実装しています（`src/db/queries.ts` の `extractRelevantSnippet()`）。
+
+### トークナイザ: `porter unicode61`
+
+```
+tokenize='porter unicode61'
+          │        │
+          │        └── Unicode正規化（大文字→小文字、アクセント除去）
+          └── Porter Stemming（語幹抽出）
+```
+
+Porter Stemming は英語の語幹を抽出するアルゴリズムです:
+
+```
+"running"  → "run"    (検索ヒット: run, runs, running)
+"types"    → "type"   (検索ヒット: type, types, typed)
+"slicing"  → "slice"  (検索ヒット: slice, slices, slicing)
+```
+
+これにより、完全一致でなくても関連する単語がヒットします。
+
+### BM25 スコアリング
+
+```sql
+-- src/db/queries.ts:128
+bm25(fts_sections, 10.0, 5.0, 1.0) as score
+--                  │     │    │
+--                  │     │    └── content の重み（基準: 1.0）
+--                  │     └── section_path の重み（中: 5.0）
+--                  └── title の重み（高: 10.0）
+```
+
+BM25 は検索結果の関連度を計算するアルゴリズムです。タイトルに一致する結果を、本文だけに一致する結果より高く評価します。
+
+**注意**: better-sqlite3 の BM25 は**負の値**を返します。値が小さいほど（より負であるほど）関連度が高いです。そのため `ORDER BY score`（昇順）で並べると、最も関連度の高い結果が先頭に来ます。
+
+## トリガーによるインデックス自動同期
+
+`sections` テーブルにデータが追加・更新・削除されたとき、FTS5インデックスが自動的に同期されます。
+
+```sql
+-- src/db/schema.ts:81-96
+
+-- INSERT時: FTS5にも追加
+CREATE TRIGGER sections_ai AFTER INSERT ON sections BEGIN
+  INSERT INTO fts_sections(rowid, title, section_path, content)
+  VALUES (new.id, new.title, new.section_path, new.fulltext);
+END;
+
+-- DELETE時: FTS5からも削除
+CREATE TRIGGER sections_ad AFTER DELETE ON sections BEGIN
+  INSERT INTO fts_sections(fts_sections, rowid, title, section_path, content)
+  VALUES ('delete', old.id, old.title, old.section_path, old.fulltext);
+END;
+
+-- UPDATE時: 古いエントリを削除 → 新しいエントリを追加
+CREATE TRIGGER sections_au AFTER UPDATE ON sections BEGIN
+  INSERT INTO fts_sections(fts_sections, rowid, title, section_path, content)
+  VALUES ('delete', old.id, old.title, old.section_path, old.fulltext);
+  INSERT INTO fts_sections(rowid, title, section_path, content)
+  VALUES (new.id, new.title, new.section_path, new.fulltext);
+END;
+```
+
+FTS5 の削除コマンドは少し特殊で、`INSERT INTO fts_sections(fts_sections, ...)` と仮想テーブル名自体を最初のカラムに指定します。これは FTS5 の仕様です。
+
+## マイグレーション
+
+**対応コード**: `src/db/schema.ts:9-33`
+
+```typescript
+// src/db/schema.ts:9-33
+export function initializeDatabase(dbPath: string): Database.Database {
+  const db = new Database(dbPath);
+
+  db.pragma('journal_mode = WAL');   // WALモードを有効化
+  db.pragma('foreign_keys = ON');    // 外部キー制約を有効化
+
+  // schema_version テーブルから現在のバージョンを取得
+  const currentVersion = row?.version ?? 0;
+
+  // バージョンが古ければマイグレーションを適用
+  if (currentVersion < 1) {
+    applyV1(db);  // 初期スキーマを作成
+  }
+  // 今後 v2, v3 を追加する場合:
+  // if (currentVersion < 2) applyV2(db);
+
+  return db;
+}
+```
+
+`schema_version` テーブルでバージョン番号を管理し、DBファイルが古い場合は自動的にスキーマを更新します。
+
+### WAL モード
+
+```
+WAL (Write-Ahead Logging):
+
+通常モード:                    WALモード:
+書き込み中は読み取りブロック    書き込みと読み取りが同時に可能
+  Writer ──X── Reader           Writer ──── Reader
+                                   │           │
+                                   v           v
+                                 WALファイル  DBファイル
+```
+
+`journal_mode = WAL` を設定すると、書き込みと読み取りを同時に行えます。これにより、`ingest`（書き込み）と `serve`（読み取り）を同時に実行しても問題ありません。
+
+## まとめ
+
+- SQLiteはファイル1つで完結するため、個人用途に最適
+- `sections` テーブルにセクション全データ、`fts_sections` にFTS5インデックス
+- `content='sections'` モードで実データとインデックスを分離
+- トリガーで FTS5 インデックスが自動同期される
+- Porter Stemming で語幹マッチング、BM25 でスコアリング
+- `schema_version` でマイグレーション管理
+
+次のドキュメント [06-mcp-server.md](./06-mcp-server.md) では、MCPサーバの実装を詳しく解説します。

--- a/docs/06-mcp-server.md
+++ b/docs/06-mcp-server.md
@@ -1,0 +1,377 @@
+# 06: MCPサーバの仕組み
+
+## このドキュメントで学ぶこと
+
+- MCPプロトコルの通信の仕組み（JSON-RPC 2.0, stdio）
+- ツール登録の方法（ListToolsRequestSchema）
+- ツール実行の流れ（CallToolRequestSchema）
+- 5つのツールの詳細な動作
+- 検索のスコアリングとスニペット抽出
+
+## MCPプロトコルの基本
+
+### JSON-RPC 2.0
+
+MCPは**JSON-RPC 2.0**というプロトコルの上に構築されています。これは「JSONでリクエストとレスポンスをやり取りする」シンプルな仕組みです。
+
+```
+リクエスト（AIからサーバへ）:
+{"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+
+レスポンス（サーバからAIへ）:
+{"jsonrpc": "2.0", "id": 1, "result": {"tools": [...]}}
+```
+
+- `method`: どんな操作をしたいか（`tools/list` = ツール一覧、`tools/call` = ツール実行）
+- `id`: リクエストとレスポンスを紐付けるための番号
+- `params`: リクエストのパラメータ
+- `result`: レスポンスの結果
+
+### stdio トランスポート
+
+```
+┌───────────────────┐     stdin      ┌───────────────────┐
+│                   │ ──────────────>│                   │
+│  Claude Desktop   │                │  langspec-mcp     │
+│  (MCPクライアント)  │     stdout     │  (MCPサーバ)       │
+│                   │ <──────────────│                   │
+└───────────────────┘                └───────────────────┘
+```
+
+MCPの通信は**標準入力（stdin）**と**標準出力（stdout）**を使って行われます。
+
+- Claude Desktop がサーバプロセスを起動する
+- stdin にJSONリクエストを書き込む
+- stdout からJSONレスポンスを読み取る
+
+**だから `console.log()` は絶対に使えません！** `console.log()` は stdout に出力するため、JSON-RPCの通信を壊してしまいます。デバッグ出力はすべて stderr（`process.stderr.write()`）に書き出します。
+
+### MCP SDKの抽象化
+
+```typescript
+// src/server.ts:1-6
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+```
+
+MCP SDKが提供する `Server` クラスと `StdioServerTransport` を使えば、JSON-RPCの解析やstdio通信の詳細を気にせず実装できます。
+
+```typescript
+// src/server.ts:25-29, 218-220
+const server = new Server(
+  { name: 'langspec-mcp', version: '1.0.0' },
+  { capabilities: { tools: {} } },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+## ツール登録 — ListToolsRequestSchema
+
+AIが「どんなツールが使えるか？」と聞いたとき、サーバはツール一覧を返します。
+
+```typescript
+// src/server.ts:34-165
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'search_spec',
+      description: 'Search language specification sections using full-text search.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Search query' },
+          language: {
+            type: 'string',
+            enum: ['go', 'java', 'rust', 'typescript'],  // 選択肢を教える
+          },
+          // ...
+        },
+        required: ['query', 'language'],
+      },
+      annotations: {
+        readOnlyHint: true,       // データを読むだけ（書き込まない）
+        destructiveHint: false,   // 破壊的操作ではない
+        idempotentHint: true,     // 何度呼んでも同じ結果
+      },
+    },
+    // ... 他のツール
+  ],
+}));
+```
+
+ポイント:
+
+- **`inputSchema`**: JSON Schema形式で引数の型を定義。AIはこれを見て正しい引数を組み立てる
+- **`enum`**: 選択可能な値を列挙。AIが存在しない言語を指定するのを防ぐ
+- **`annotations`**: ツールの性質をAIに伝える。読み取り専用なので安全に呼べる
+
+`enum` の値は `getSupportedLanguages()` から動的に生成されます（`src/server.ts:31`）。言語を追加すると自動的にツールの選択肢にも反映されます。
+
+## ツール実行 — CallToolRequestSchema
+
+AIがツールを呼ぶと、`{name, arguments}` がリクエストとして届きます。
+
+```typescript
+// src/server.ts:168-216
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  try {
+    switch (name) {
+      case 'search_spec': {
+        const params = SearchSpecInputSchema.parse(args);  // Zodでバリデーション
+        const result = searchSpec(db, params);              // ハンドラ関数を呼び出し
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify(result, null, 2)           // JSON文字列で返す
+          }]
+        };
+      }
+      // ... 他のツール
+    }
+  } catch (error) {
+    // エラー時は isError: true をセット
+    return {
+      content: [{ type: 'text', text: `Error: ${message}` }],
+      isError: true,
+    };
+  }
+});
+```
+
+処理の流れ:
+
+```
+1. AIが tools/call リクエストを送信
+   {"method": "tools/call", "params": {"name": "search_spec", "arguments": {"query": "slice", "language": "go"}}}
+       │
+       v
+2. switch文でツール名を判定
+       │
+       v
+3. Zodスキーマでバリデーション
+   SearchSpecInputSchema.parse(args)
+   → 不正な引数ならZodErrorをスロー
+       │
+       v
+4. ハンドラ関数を呼び出し
+   searchSpec(db, params)
+       │
+       v
+5. 結果をJSON文字列にしてレスポンス
+   { content: [{ type: "text", text: "..." }] }
+```
+
+### Zodバリデーション
+
+**対応コード**: `src/types.ts:120-152`
+
+Zodは実行時の型チェックライブラリです。AIから送られてきたパラメータが正しい型かどうかを検証します。
+
+```typescript
+// src/types.ts:130-139
+export const SearchSpecInputSchema = z.object({
+  query: z.string().min(1),          // 空文字は拒否
+  language: LanguageEnum,             // 登録済み言語のみ許可
+  version: z.string().optional(),     // 省略可能
+  filters: z.object({
+    doc: z.string().optional(),
+    section_path_prefix: z.string().optional(),
+    limit: z.number().int().min(1).max(50).optional(),
+  }).optional(),
+});
+```
+
+## 5つのツール詳細
+
+### `list_languages` — 対応言語一覧
+
+**対応コード**: `src/tools/list-languages.ts`
+
+データベースに取り込み済みの言語一覧を返します。
+
+```
+入力: なし
+出力: [
+  { language: "go", docs: ["go-spec"] },
+  { language: "java", docs: ["jls"] },
+  ...
+]
+```
+
+### `list_versions` — バージョン一覧
+
+**対応コード**: `src/tools/list-versions.ts`
+
+指定した言語の取得済みバージョン一覧を返します。
+
+```
+入力: { language: "go" }
+出力: [
+  { version: "snapshot-20260208", fetched_at: "2026-02-08T...", source_url: "..." }
+]
+```
+
+### `search_spec` — 全文検索
+
+**対応コード**: `src/tools/search-spec.ts`, `src/db/queries.ts:97-158`
+
+FTS5 を使って仕様書を全文検索し、関連度順に結果を返します。
+
+```
+入力: { query: "slice types", language: "go" }
+出力: [
+  {
+    title: "Slice types",
+    section_path: "Types > Slice types",
+    url: "https://go.dev/ref/spec#Slice_types",
+    snippet: { text: "A slice is a descriptor for a contiguous segment...", ... },
+    score: -15.234  (負の値。小さいほど関連度が高い)
+  },
+  ...
+]
+```
+
+検索の流れ:
+
+```
+1. バージョン未指定なら最新スナップショットのバージョンを取得
+2. FTS5クエリを実行（BM25スコアリング付き）
+3. 各結果に対してスニペットを抽出
+4. Citation配列として返す
+```
+
+### `get_section` — セクション全文取得
+
+**対応コード**: `src/tools/get-section.ts`
+
+`search_spec` で見つけたセクションの全文を取得します。
+
+```
+入力: { language: "go", version: "snapshot-20260208", section_id: "Slice_types" }
+出力: {
+  citation: { title: "Slice types", url: "...", ... },
+  content: {
+    excerpt: "最初の1200文字...",
+    is_truncated: true,
+    fulltext_available: false,   // excerpt_onlyなので全文は非公開
+  }
+}
+```
+
+`source_policy` に応じて全文の公開を制御します:
+
+```typescript
+// src/tools/get-section.ts:28-51
+const fulltextAvailable = section.source_policy === 'local_fulltext_ok';
+// Go/Java → excerpt のみ
+// Rust/TypeScript → fulltext も含めて返す
+```
+
+### `build_learning_plan` — 学習プラン生成
+
+**対応コード**: `src/tools/build-learning-plan.ts`
+
+仕様書のセクション一覧から、指定した週数に分割した学習プランを生成します。
+
+```
+入力: { language: "go", total_weeks: 4, focus_areas: ["Types"] }
+出力: {
+  weeks: [
+    {
+      week: 1,
+      theme: "Introduction, Lexical elements",
+      sections: [...],
+      estimated_minutes: 45
+    },
+    {
+      week: 2,
+      theme: "Types",           // focus_areas が優先的に配置される
+      sections: [...],
+      estimated_minutes: 60
+    },
+    ...
+  ]
+}
+```
+
+プラン生成の流れ:
+
+```
+1. 全セクションをトップレベルトピックごとにグループ化
+   groupByTopLevel(): section_path の最初の部分でグルーピング
+
+2. focus_areas による並べ替え
+   reorderForFocus(): 指定トピックを前方に移動（前提トピックは先頭維持）
+
+3. 週への割り当て
+   assignToWeeks(): コンテンツ量（文字数）で均等に分配
+   ├── 目標: totalChars / totalWeeks 文字/週
+   ├── 閾値超過で次の週に移行
+   └── 推定時間: 800文字/分で計算
+```
+
+## 検索の深掘り: スニペット抽出
+
+**対応コード**: `src/db/queries.ts:218-269`
+
+FTS5 の content-sync モードでは `snippet()` 関数が使えないため、独自にスニペットを抽出しています。
+
+```typescript
+// src/db/queries.ts:218-269
+export function extractRelevantSnippet(text: string, query: string, maxLen = 300) {
+  // 1. テキストが十分短ければそのまま返す
+  if (text.length <= maxLen) return { text, start_char: 0, end_char: text.length };
+
+  // 2. クエリをトークンに分割（FTS5演算子を除外）
+  const tokens = query.split(/\s+/)
+    .filter(t => !['AND', 'OR', 'NOT', 'NEAR'].includes(t.toUpperCase()));
+
+  // 3. テキスト内でトークンが最初に出現する位置を探す
+  for (const token of tokens) {
+    const pos = lowerText.indexOf(token.toLowerCase());
+    if (pos !== -1 && (bestPos === -1 || pos < bestPos)) {
+      bestPos = pos;
+    }
+  }
+
+  // 4. その位置を中心に300文字のウィンドウを切り出す
+  const half = Math.floor(maxLen / 2);
+  let start = Math.max(0, bestPos - half);
+  let end = start + maxLen;
+}
+```
+
+動作イメージ:
+
+```
+全文（2000文字）:
+"...前略... A slice is a descriptor for a contiguous segment of
+an underlying array and provides access to a numbered sequence
+of elements from that array. ...後略..."
+
+クエリ: "slice"
+
+スニペット:
+"...A slice is a descriptor for a contiguous segment of an
+underlying array and provides access to a numbered sequence..."
+  ↑ "slice" の出現位置を中心に300文字を切り出し
+```
+
+## まとめ
+
+- MCPは JSON-RPC 2.0 + stdio で通信する
+- `console.log()` は厳禁。stdoutはJSON-RPC専用
+- `ListToolsRequestSchema` でツール一覧を、`CallToolRequestSchema` でツール実行を処理
+- Zodでパラメータをバリデーションし、不正な入力を拒否
+- 5つのツール: メタデータ参照(2) + 全文検索 + セクション取得 + 学習プラン生成
+- スニペット抽出はクエリトークンの出現位置を中心にウィンドウを切り出す
+
+次のドキュメント [07-reliability.md](./07-reliability.md) では、信頼性を支える仕組みを解説します。

--- a/docs/07-reliability.md
+++ b/docs/07-reliability.md
@@ -1,0 +1,412 @@
+# 07: 信頼性を支える仕組み (NFR)
+
+## このドキュメントで学ぶこと
+
+- 構造化ログの仕組みと使い方
+- リトライ（自動再試行）の戦略
+- ディスクキャッシュによる通信量削減
+- 適応的レート制限の動作
+
+NFR (Non-Functional Requirements = 非機能要件) とは、「正しく動く」だけでなく「安定して動く」「壊れにくい」「効率的に動く」といった品質に関する要件です。
+
+## 構造化ログ
+
+**対応コード**: `src/lib/logger.ts`
+
+### なぜ構造化ログか
+
+通常のログ:
+```
+[2026-02-08 12:00:00] INFO: Fetching https://go.dev/ref/spec
+[2026-02-08 12:00:01] ERROR: Failed to fetch: 429 Too Many Requests
+```
+
+構造化ログ（JSON Lines）:
+```json
+{"ts":"2026-02-08T12:00:00.000Z","level":"info","component":"Fetcher","msg":"Fetching","url":"https://go.dev/ref/spec"}
+{"ts":"2026-02-08T12:00:01.000Z","level":"error","component":"Fetcher","msg":"Failed to fetch","status":429,"url":"https://go.dev/ref/spec"}
+```
+
+構造化ログの利点:
+
+- **プログラムで解析しやすい**: JSON.parse() で読み込み、フィルタリングや集計ができる
+- **grep しやすい**: `grep '"level":"error"'` でエラーだけ抽出
+- **コンポーネント別に追跡**: `component` フィールドでどのモジュールのログか一目瞭然
+
+### 実装
+
+```typescript
+// src/lib/logger.ts:34-60
+export function createLogger(component: string): Logger {
+  function log(level: LogLevel, msg: string, data?: Record<string, unknown>): void {
+    // ログレベルフィルタ: 設定レベル未満は出力しない
+    if (LEVEL_ORDER[level] < LEVEL_ORDER[globalLevel]) return;
+
+    const entry: Record<string, unknown> = {
+      ts: new Date().toISOString(),
+      level,
+      component,
+      msg,
+    };
+
+    // 追加データをマージ
+    if (data) {
+      for (const [key, value] of Object.entries(data)) {
+        entry[key] = value;
+      }
+    }
+
+    // stderrに出力（stdoutはJSON-RPC通信用なので使えない！）
+    process.stderr.write(JSON.stringify(entry) + '\n');
+  }
+
+  return {
+    debug: (msg, data?) => log('debug', msg, data),
+    info:  (msg, data?) => log('info', msg, data),
+    warn:  (msg, data?) => log('warn', msg, data),
+    error: (msg, data?) => log('error', msg, data),
+  };
+}
+```
+
+### 使い方
+
+```typescript
+// 各モジュールの冒頭で作成
+const log = createLogger('Fetcher');   // src/ingestion/fetcher.ts:8
+const log = createLogger('Parser');    // src/ingestion/parser.ts:6
+const log = createLogger('DB');        // src/db/schema.ts:5
+const log = createLogger('Server');    // src/server.ts:10
+
+// ログ出力
+log.info('Fetching', { url: 'https://go.dev/ref/spec' });
+log.warn('Rate limited', { status: 429, retryAfter: 5 });
+log.error('Fatal error', { error: 'Connection refused' });
+```
+
+### ログレベル制御
+
+```typescript
+// src/lib/logger.ts:3-8
+const LEVEL_ORDER: Record<LogLevel, number> = {
+  debug: 0,   // 最も詳細（通常は非表示）
+  info: 1,    // 通常の情報（デフォルト）
+  warn: 2,    // 警告
+  error: 3,   // エラー
+};
+```
+
+環境変数 `LOG_LEVEL` で出力レベルを制御します:
+
+```bash
+# 通常実行（infoレベル以上を表示）
+npm run ingest -- --language go
+
+# デバッグ実行（全レベルを表示）
+LOG_LEVEL=debug npm run ingest -- --language go
+
+# エラーのみ表示
+LOG_LEVEL=error npm run ingest -- --language go
+```
+
+`LOG_LEVEL=debug` に設定すると、各ページの取得状況や解析結果など、詳細な情報が表示されます。
+
+## リトライ（自動再試行）
+
+**対応コード**: `src/lib/retry.ts`
+
+HTTP通信は失敗することがあります。サーバが一時的にダウンしていたり、レート制限に引っかかったりする場合です。
+
+### `withRetry()` — リトライラッパー
+
+```typescript
+// src/lib/retry.ts:36-77
+export async function withRetry<T>(fn: () => Promise<T>, opts: RetryOptions = {}): Promise<T> {
+  const maxRetries = opts.maxRetries ?? 3;
+  const initialDelayMs = opts.initialDelayMs ?? 1000;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      if (attempt >= maxRetries || !isRetryable(error)) {
+        throw error;  // リトライ不可 or 上限到達 → 諦める
+      }
+
+      // 待機時間を計算して待つ
+      const delayMs = jitter(initialDelayMs * Math.pow(2, attempt));
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+}
+```
+
+使い方はシンプルです。非同期関数を `withRetry()` で囲むだけです:
+
+```typescript
+// src/ingestion/fetcher.ts:34-63
+async function fetchUrl(url: string, knownEtag?: string): Promise<FetchUrlResult> {
+  return withRetry(async () => {
+    const response = await fetch(url, { ... });
+    if (!response.ok) {
+      throw new FetchError(...);
+    }
+    return { body: await response.text(), etag, status: 200 };
+  });
+}
+```
+
+### 指数バックオフ + ジッター
+
+リトライの待機時間は「指数バックオフ」で増加します:
+
+```
+試行1失敗 → 約1秒待つ  (1000ms × 2^0 = 1000ms)
+試行2失敗 → 約2秒待つ  (1000ms × 2^1 = 2000ms)
+試行3失敗 → 約4秒待つ  (1000ms × 2^2 = 4000ms)
+試行4失敗 → 諦める
+```
+
+さらに「ジッター（ゆらぎ）」を±25%加えます:
+
+```typescript
+// src/lib/retry.ts:30-34
+function jitter(baseMs: number): number {
+  const factor = 0.75 + Math.random() * 0.5;  // 0.75 〜 1.25
+  return Math.round(baseMs * factor);
+}
+```
+
+```
+1000ms × ジッター → 750ms 〜 1250ms の間でランダム
+```
+
+なぜジッターを入れるのか？ 複数のクライアントが同時にリトライすると、同じタイミングでサーバに殺到してしまいます（「サンダリングハード問題」）。ジッターでタイミングをずらすことで、この問題を避けられます。
+
+### リトライ判定
+
+すべてのエラーをリトライするわけではありません:
+
+```typescript
+// src/lib/retry.ts:11-28
+function defaultIsRetryable(error: unknown): boolean {
+  if (error instanceof FetchError) {
+    if (error.status === 429) return true;   // Too Many Requests → リトライ
+    if (error.status >= 500) return true;     // サーバエラー → リトライ
+    return false;                             // 404など → リトライしない
+  }
+  if (error instanceof TypeError) return true; // DNS/接続エラー → リトライ
+  return false;
+}
+```
+
+| ステータス | 判定 | 理由 |
+|-----------|------|------|
+| 429 | リトライする | 一時的なレート制限 |
+| 500-599 | リトライする | サーバ側の一時的な問題 |
+| 404 | リトライしない | ページが存在しない（何度やっても同じ） |
+| TypeError | リトライする | DNS解決失敗や接続エラー（一時的な可能性） |
+
+### `Retry-After` ヘッダー対応
+
+429 応答には `Retry-After` ヘッダーが含まれることがあります。「この秒数待ってから再試行して」という指示です:
+
+```typescript
+// src/lib/retry.ts:58-63
+if (error instanceof FetchError && error.retryAfter != null) {
+  delayMs = error.retryAfter * 1000;  // サーバの指示に従う
+} else {
+  delayMs = jitter(initialDelayMs * Math.pow(2, attempt));  // 指数バックオフ
+}
+```
+
+### `FetchError` クラス
+
+```typescript
+// src/lib/retry.ts:79-89
+export class FetchError extends Error {
+  constructor(
+    message: string,
+    public readonly url: string,       // 失敗したURL
+    public readonly status: number,    // HTTPステータスコード
+    public readonly retryAfter?: number, // Retry-Afterヘッダーの値（秒）
+  ) {
+    super(message);
+    this.name = 'FetchError';
+  }
+}
+```
+
+通常の `Error` を拡張し、HTTP固有の情報（URL, ステータスコード, Retry-After）を保持します。リトライ判定やログ出力で使われます。
+
+## ディスクキャッシュ
+
+**対応コード**: `src/lib/cache.ts`
+
+2回目以降の `ingest` では、前回ダウンロードした内容をディスクにキャッシュして再利用します。
+
+### キャッシュの仕組み
+
+```
+初回 ingest:
+  fetch(url) → 200 OK → HTMLをDBに保存 + キャッシュに保存
+
+2回目 ingest:
+  fetch(url, If-None-Match: "前回のETag")
+  → 304 Not Modified → キャッシュから読み込み（ダウンロード不要！）
+  → 200 OK → 新しい内容でキャッシュを更新
+```
+
+### ファイル構造
+
+```
+data/cache/
+├── go/
+│   └── go-spec/
+│       ├── a1b2c3d4e5f6g7h8.html        ← キャッシュ本体
+│       └── a1b2c3d4e5f6g7h8.meta.json   ← メタデータ（ETag, URL, 取得日時）
+├── java/
+│   └── jls/
+│       ├── 1234abcd5678efgh.html
+│       ├── 1234abcd5678efgh.meta.json
+│       └── ...（各章ごとにファイル）
+└── ...
+```
+
+ファイル名はURLのSHA-256ハッシュの先頭16文字です:
+
+```typescript
+// src/lib/cache.ts:22-24
+private keyFor(url: string): string {
+  return createHash('sha256').update(url).digest('hex').substring(0, 16);
+}
+```
+
+### メタデータ
+
+```json
+// .meta.json の例
+{
+  "url": "https://go.dev/ref/spec",
+  "etag": "\"abc123\"",
+  "fetchedAt": "2026-02-08T03:00:00.000Z"
+}
+```
+
+### キャッシュの利用
+
+```typescript
+// src/ingestion/fetcher.ts:72-93
+async function fetchWithCache(url: string, ctx?: CacheContext): Promise<FetchUrlResult> {
+  // 1. キャッシュからETagを取得
+  const cachedEtag = ctx?.cache.getMeta(ctx.language, ctx.doc, url)?.etag;
+
+  // 2. ETag付きでHTTPリクエスト
+  const result = await fetchUrl(url, cachedEtag);
+
+  // 3. 304 Not Modified → キャッシュから読み込み
+  if (result.status === 304 && ctx) {
+    const cached = ctx.cache.getContent(ctx.language, ctx.doc, url);
+    if (cached != null) {
+      return { body: cached, etag: result.etag, status: 304 };
+    }
+  }
+
+  // 4. 200 OK → キャッシュを更新
+  if (result.status === 200 && result.body != null && ctx) {
+    ctx.cache.put(ctx.language, ctx.doc, url, result.body, result.etag);
+  }
+
+  return result;
+}
+```
+
+### 効果
+
+```
+初回 ingest (Java JLS):
+  19章 × 平均100KB = 約1.9MB ダウンロード
+  所要時間: 約30秒
+
+2回目 ingest (変更なし):
+  19章 × HEAD相当リクエスト = ほぼ0KB
+  所要時間: 約5秒
+```
+
+## 適応的レート制限
+
+**対応コード**: `src/ingestion/fetcher.ts:16-25`
+
+マルチページ取得時に 429 (Too Many Requests) を受け取ったら、リクエスト間の遅延を自動的に増やします。
+
+```typescript
+// src/ingestion/fetcher.ts:16-25
+export function adaptDelay(currentDelayMs: number, error: unknown): number {
+  if (error instanceof FetchError && error.status === 429) {
+    const newDelay = error.retryAfter != null
+      ? error.retryAfter * 1000                    // Retry-After に従う
+      : Math.min(currentDelayMs * 2, 10_000);      // なければ倍増（上限10秒）
+    return newDelay;
+  }
+  return currentDelayMs;  // 429以外はそのまま
+}
+```
+
+動作の流れ:
+
+```
+ページ1: 200ms待って取得 → OK
+ページ2: 200ms待って取得 → OK
+ページ3: 200ms待って取得 → 429! (リトライで成功)
+                              ↓
+          delayMs を 200ms → 400ms に増加
+                              ↓
+ページ4: 400ms待って取得 → OK
+ページ5: 400ms待って取得 → OK
+...
+```
+
+取得ループ内での使用:
+
+```typescript
+// src/ingestion/fetcher.ts:160-176（multi-html-toc の例）
+let delayMs = 200;
+for (const link of chapterLinks) {
+  try {
+    const result = await fetchWithCache(chapterUrl, ctx);
+    results.push(result);
+  } catch (err) {
+    errors.push({ url: chapterUrl, error: msg });
+    delayMs = adaptDelay(delayMs, err);  // 429なら遅延を増加
+  }
+  await delay(delayMs);
+}
+```
+
+## タイムアウト
+
+すべてのHTTPリクエストに30秒のタイムアウトを設定しています:
+
+```typescript
+// src/ingestion/fetcher.ts:10-11
+const FETCH_TIMEOUT_MS = 30_000;
+
+// src/ingestion/fetcher.ts:42
+const response = await fetch(url, {
+  signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+});
+```
+
+`AbortSignal.timeout()` は Node.js 18 以降で使える機能です。指定時間内に応答がなければリクエストを中断し、`AbortError` をスローします。これもリトライ対象です（`src/lib/retry.ts:25`）。
+
+## まとめ
+
+| 仕組み | 目的 | 対応コード |
+|--------|------|-----------|
+| 構造化ログ | 問題の追跡と診断 | `src/lib/logger.ts` |
+| リトライ | 一時的な障害からの自動復旧 | `src/lib/retry.ts` |
+| ディスクキャッシュ | 通信量の削減と高速化 | `src/lib/cache.ts` |
+| 適応的レート制限 | サーバへの過負荷防止 | `src/ingestion/fetcher.ts` |
+| タイムアウト | ハングアップ防止 | `src/ingestion/fetcher.ts` |
+
+これらの仕組みが連携して、ネットワーク障害やサーバの一時的な問題があっても、可能な限り処理を継続し、回復できるようにしています。

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,81 @@
+# langspec-mcp アーキテクチャ解説
+
+プログラミング言語の仕様書をインデックス化し、AI（Claude）から全文検索・引用ができるMCPサーバの設計と実装を解説するドキュメント集です。
+
+## 前提知識
+
+- Node.js と npm の基本的な使い方（`npm install`, `npm run` など）
+- ターミナル（コマンドライン）の基本操作
+- JavaScript の基礎文法（TypeScript は本ドキュメント内で解説します）
+
+## 読み順ガイド
+
+| # | ファイル | 内容 | 読了目安 |
+|---|---------|------|---------|
+| 1 | [01-overview.md](./01-overview.md) | MCPとは何か、このサーバが解決する問題 | 10分 |
+| 2 | [02-typescript-basics.md](./02-typescript-basics.md) | TypeScriptプロジェクトの構造とビルドの仕組み | 15分 |
+| 3 | [03-config.md](./03-config.md) | 言語設定レジストリ — 新しい言語を追加する方法 | 10分 |
+| 4 | [04-ingestion-pipeline.md](./04-ingestion-pipeline.md) | 仕様書のダウンロード・解析・保存の全工程 | 20分 |
+| 5 | [05-database.md](./05-database.md) | SQLite + FTS5 によるデータベース設計 | 15分 |
+| 6 | [06-mcp-server.md](./06-mcp-server.md) | MCPサーバの仕組みとツール実装 | 20分 |
+| 7 | [07-reliability.md](./07-reliability.md) | 信頼性を支える仕組み（ログ・リトライ・キャッシュ） | 15分 |
+
+各ドキュメントは独立して読めますが、番号順に読むと理解がスムーズです。
+
+## アーキテクチャ全体図
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        langspec-mcp                             │
+│                                                                 │
+│  ┌──────────┐    ┌──────────────────────────────────────────┐   │
+│  │  CLI     │    │          Ingestion Pipeline              │   │
+│  │ index.ts │───>│                                          │   │
+│  │          │    │  fetcher ──> parser ──> normalizer ──>DB │   │
+│  │ ingest   │    │  (HTTP)     (HTML/MD)   (hash/URL)       │   │
+│  └──────────┘    └──────────────────────────────────────────┘   │
+│       │                                        │                │
+│       │                                        v                │
+│       │          ┌────────────────┐    ┌──────────────┐         │
+│       │          │    SQLite DB   │    │  Disk Cache  │         │
+│       │          │  ┌──────────┐  │    │  data/cache/ │         │
+│       │          │  │ sections │  │    └──────────────┘         │
+│       │          │  │ snapshots│  │                              │
+│       │          │  │ FTS5 idx │  │                              │
+│       │          │  └──────────┘  │                              │
+│       │          └────────────────┘                              │
+│       │                  ^                                      │
+│       v                  │                                      │
+│  ┌──────────┐    ┌──────────────────────────────────────────┐   │
+│  │  CLI     │    │           MCP Server                     │   │
+│  │ index.ts │───>│                                          │   │
+│  │          │    │  list_languages  search_spec              │   │
+│  │  serve   │    │  list_versions   get_section              │   │
+│  └──────────┘    │  build_learning_plan                      │   │
+│                  └──────────────────────────────────────────┘   │
+│                          │          ^                            │
+└──────────────────────────│──────────│────────────────────────────┘
+                           v          │
+                    ┌──────────────────────┐
+                    │   Claude Desktop     │
+                    │   (stdin/stdout)     │
+                    │                      │
+                    │  JSON-RPC over stdio │
+                    └──────────────────────┘
+```
+
+## 2つのコマンド
+
+このサーバには2つの動作モードがあります:
+
+1. **`npm run ingest`** — 仕様書をインターネットからダウンロードし、SQLiteデータベースに保存する
+2. **`npm run serve`** — MCPサーバを起動し、Claude DesktopなどのAIツールに検索機能を提供する
+
+## 対応言語
+
+| 言語 | 仕様書 | 取得方法 | セクション数 |
+|------|--------|---------|-------------|
+| Go | The Go Programming Language Specification | 1ページHTML | ~162 |
+| Java | Java Language Specification (SE21) | 目次+複数章HTML | ~575 |
+| Rust | The Rust Reference | GitHub Markdown | ~1401 |
+| TypeScript | TypeScript Handbook | GitHub Markdown | ~178 |


### PR DESCRIPTION
## Summary
- Add 7-chapter Japanese architecture documentation in `docs/` directory
- Cover MCP overview, TypeScript basics, config registry, ingestion pipeline, database design, MCP server implementation, and reliability patterns
- Update CLAUDE.md with documentation section

## Included PRs
- #26 docs: add architecture documentation (feature/25-architecture-docs → develop)

## Files Added/Modified
| File | Content |
|------|---------|
| `docs/README.md` | Table of contents, reading guide, architecture diagram |
| `docs/01-overview.md` | What is MCP, two commands (ingest/serve) |
| `docs/02-typescript-basics.md` | package.json, tsconfig.json, ES Modules, `.js` imports |
| `docs/03-config.md` | LanguageConfig, 3 FetchStrategies, sourcePolicy |
| `docs/04-ingestion-pipeline.md` | Fetch → Parse → Normalize → Persist pipeline |
| `docs/05-database.md` | SQLite + FTS5, triggers, BM25, migrations |
| `docs/06-mcp-server.md` | JSON-RPC/stdio, tool registration, 5 tools detail |
| `docs/07-reliability.md` | Structured logging, retry, disk cache, rate limiting |
| `CLAUDE.md` | Added Documentation section |

## Test plan
- [x] `npm run build` passes (no code changes)
- [x] `npm test` — 102 tests pass
- [x] All source file paths referenced in docs verified to exist

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)