### PR TITLE
feat: Vitest docs support and generic IT document ingestion (M6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@
 - **M3完了**: build_learning_plan tool (週間学習プラン自動生成)
 - **M4完了**: 多言語対応 (Go, Java, Rust, TypeScript)
 - **M5完了**: NFR堅牢化 (構造化ログ, retry/timeout, ETag, disk cache, 部分失敗回復, adaptive rate limiting)
-- ~2,316セクション indexed、5 MCP tools稼働、102 tests
+- **M6完了**: Vitest ドキュメント対応 + 汎用IT技術ドキュメント取り込み (再帰ディレクトリ探索, excludePaths, urlSuffix, chapterPattern汎化)
+- ~3,900セクション indexed (Go 162, Java 575, Rust 1401, TypeScript 178, Vitest ~1587)、5 MCP tools稼働、112 tests
 
 ## Tech Stack
 - TypeScript (ES modules, `"type": "module"`, `"module": "Node16"`)
@@ -30,7 +31,7 @@ src/
 ├── server.ts            # MCP Server + tool registration
 ├── types.ts             # TypeScript types + Zod schemas (FetchOutcome etc.)
 ├── config/
-│   └── languages.ts     # LanguageConfig registry (4 languages)
+│   └── languages.ts     # LanguageConfig registry (5 languages)
 ├── db/
 │   ├── schema.ts        # DB init + migrations
 │   └── queries.ts       # DatabaseQueries + extractRelevantSnippet()

--- a/src/config/languages.ts
+++ b/src/config/languages.ts
@@ -19,6 +19,8 @@ export interface DocConfig {
   githubPath?: string;
   manifestFile?: string;
   canonicalBaseUrl?: string;
+  excludePaths?: string[];
+  urlSuffix?: string;
 }
 
 export interface LanguageConfig {
@@ -55,6 +57,7 @@ const LANGUAGES: LanguageConfig[] = [
         headingSelectors: 'h2, h3, h4',
         sourcePolicy: 'excerpt_only',
         canonicalBaseUrl: 'https://docs.oracle.com/javase/specs/jls/se21/html',
+        chapterPattern: /^jls-\d+\.html$/,
         notes: 'Oracle著作権のためexcerpt_only',
       },
     ],
@@ -89,6 +92,24 @@ const LANGUAGES: LanguageConfig[] = [
         githubPath: 'packages/documentation/copy/en/handbook-v2',
         sourcePolicy: 'local_fulltext_ok',
         notes: 'Handbookは完全な仕様書ではない（公式明記）',
+      },
+    ],
+  },
+  {
+    language: 'vitest',
+    displayName: 'Vitest',
+    docs: [
+      {
+        doc: 'vitest-docs',
+        displayName: 'Vitest Documentation',
+        fetchStrategy: 'github-markdown',
+        githubOwner: 'vitest-dev',
+        githubRepo: 'vitest',
+        githubPath: 'docs',
+        sourcePolicy: 'local_fulltext_ok',
+        canonicalBaseUrl: 'https://vitest.dev',
+        excludePaths: ['.vitepress', 'team', 'public'],
+        urlSuffix: '',
       },
     ],
   },

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -59,6 +59,7 @@ export async function ingestSpec(db: Database.Database, language: string, cacheD
       baseUrl: docConfig.canonicalBaseUrl ?? docConfig.url ?? '',
       sourcePolicy: docConfig.sourcePolicy,
       pageUrlPrefix: docConfig.githubPath,
+      urlSuffix: docConfig.urlSuffix,
     });
     allNormalized.push(...normalized);
   }

--- a/src/ingestion/normalizer.ts
+++ b/src/ingestion/normalizer.ts
@@ -10,6 +10,7 @@ export function normalizeSections(
     baseUrl: string;
     sourcePolicy?: string;
     pageUrlPrefix?: string;
+    urlSuffix?: string;
   },
 ): NormalizedSection[] {
   const policy = meta.sourcePolicy ?? 'excerpt_only';
@@ -20,7 +21,7 @@ export function normalizeSections(
       ? fulltext.substring(0, EXCERPT_MAX_LENGTH) + '...'
       : fulltext;
 
-    const canonicalUrl = buildCanonicalUrl(meta.baseUrl, s.section_id, s.pageUrl, meta.pageUrlPrefix);
+    const canonicalUrl = buildCanonicalUrl(meta.baseUrl, s.section_id, s.pageUrl, meta.pageUrlPrefix, meta.urlSuffix);
 
     return {
       language: meta.language,
@@ -38,7 +39,7 @@ export function normalizeSections(
   });
 }
 
-function buildCanonicalUrl(baseUrl: string, sectionId: string, pageUrl?: string, pageUrlPrefix?: string): string {
+function buildCanonicalUrl(baseUrl: string, sectionId: string, pageUrl?: string, pageUrlPrefix?: string, urlSuffix?: string): string {
   if (!pageUrl) {
     // Single-page: baseUrl#sectionId (Go)
     return `${baseUrl}#${sectionId}`;
@@ -60,5 +61,6 @@ function buildCanonicalUrl(baseUrl: string, sectionId: string, pageUrl?: string,
   }
   pageName = pageName.replace(/\.md$/, '');
 
-  return `${baseUrl}/${pageName}.html#${sectionId}`;
+  const suffix = urlSuffix ?? '.html';
+  return `${baseUrl}/${pageName}${suffix}#${sectionId}`;
 }

--- a/tests/language-config.test.ts
+++ b/tests/language-config.test.ts
@@ -7,13 +7,14 @@ import {
 } from '../src/config/languages.js';
 
 describe('LanguageConfig registry', () => {
-  it('getSupportedLanguages returns all 4 languages', () => {
+  it('getSupportedLanguages returns all 5 languages', () => {
     const langs = getSupportedLanguages();
     expect(langs).toContain('go');
     expect(langs).toContain('java');
     expect(langs).toContain('rust');
     expect(langs).toContain('typescript');
-    expect(langs).toHaveLength(4);
+    expect(langs).toContain('vitest');
+    expect(langs).toHaveLength(5);
   });
 
   it('getLanguageConfig returns config for each language', () => {

--- a/tests/vitest-config.test.ts
+++ b/tests/vitest-config.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { getDocConfig, getLanguageConfig } from '../src/config/languages.js';
+import { normalizeSections } from '../src/ingestion/normalizer.js';
+import type { ParsedSection } from '../src/types.js';
+
+describe('Vitest config', () => {
+  it('vitest language config exists and is well-formed', () => {
+    const config = getLanguageConfig('vitest');
+    expect(config.language).toBe('vitest');
+    expect(config.displayName).toBe('Vitest');
+    expect(config.docs).toHaveLength(1);
+  });
+
+  it('vitest doc config has correct github-markdown settings', () => {
+    const doc = getDocConfig('vitest');
+    expect(doc.fetchStrategy).toBe('github-markdown');
+    expect(doc.githubOwner).toBe('vitest-dev');
+    expect(doc.githubRepo).toBe('vitest');
+    expect(doc.githubPath).toBe('docs');
+    expect(doc.sourcePolicy).toBe('local_fulltext_ok');
+    expect(doc.canonicalBaseUrl).toBe('https://vitest.dev');
+    expect(doc.excludePaths).toEqual(['.vitepress', 'team', 'public']);
+    expect(doc.urlSuffix).toBe('');
+  });
+
+  it('java config has explicit chapterPattern', () => {
+    const doc = getDocConfig('java');
+    expect(doc.chapterPattern).toBeDefined();
+    expect(doc.chapterPattern!.test('jls-4.html')).toBe(true);
+    expect(doc.chapterPattern!.test('index.html')).toBe(false);
+  });
+});
+
+describe('urlSuffix in canonical URL', () => {
+  function makeParsedSection(overrides?: Partial<ParsedSection>): ParsedSection {
+    return {
+      section_id: 'mock-timers',
+      title: 'Mock Timers',
+      section_path: 'Guide > Mock Timers',
+      content: 'Vitest mock timers content',
+      heading_level: 2,
+      ...overrides,
+    };
+  }
+
+  it('uses empty urlSuffix for VitePress clean URLs', () => {
+    const sections = [makeParsedSection({
+      section_id: 'mock-timers',
+      pageUrl: 'docs/guide/mocking.md',
+    })];
+    const result = normalizeSections(sections, {
+      language: 'vitest',
+      doc: 'vitest-docs',
+      version: 'snapshot-20260211',
+      baseUrl: 'https://vitest.dev',
+      pageUrlPrefix: 'docs',
+      urlSuffix: '',
+    });
+
+    expect(result[0].canonical_url).toBe('https://vitest.dev/guide/mocking#mock-timers');
+  });
+
+  it('uses .html suffix by default (backward compat)', () => {
+    const sections = [makeParsedSection({
+      section_id: 'boolean-type',
+      pageUrl: 'src/types.md',
+    })];
+    const result = normalizeSections(sections, {
+      language: 'rust',
+      doc: 'rust-reference',
+      version: 'snapshot-20260211',
+      baseUrl: 'https://doc.rust-lang.org/reference',
+      pageUrlPrefix: 'src',
+    });
+
+    expect(result[0].canonical_url).toBe('https://doc.rust-lang.org/reference/types.html#boolean-type');
+  });
+
+  it('handles nested subdirectory paths with empty urlSuffix', () => {
+    const sections = [makeParsedSection({
+      section_id: 'viewport-api',
+      pageUrl: 'docs/guide/browser/commands.md',
+    })];
+    const result = normalizeSections(sections, {
+      language: 'vitest',
+      doc: 'vitest-docs',
+      version: 'snapshot-20260211',
+      baseUrl: 'https://vitest.dev',
+      pageUrlPrefix: 'docs',
+      urlSuffix: '',
+    });
+
+    expect(result[0].canonical_url).toBe('https://vitest.dev/guide/browser/commands#viewport-api');
+  });
+});

--- a/tests/vitest-ingestion.test.ts
+++ b/tests/vitest-ingestion.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type Database from 'better-sqlite3';
+import { initializeDatabase } from '../src/db/schema.js';
+import { DatabaseQueries } from '../src/db/queries.js';
+import { ingestSpec } from '../src/ingestion/index.js';
+
+describe('Vitest ingestion (integration)', { timeout: 120_000 }, () => {
+  let db: Database.Database;
+
+  beforeAll(async () => {
+    db = initializeDatabase(':memory:');
+    await ingestSpec(db, 'vitest');
+  }, 120_000);
+
+  afterAll(() => {
+    db?.close();
+  });
+
+  it('ingests sections from vitest docs', () => {
+    const queries = new DatabaseQueries(db);
+    const count = db.prepare('SELECT COUNT(*) as cnt FROM sections WHERE language = ?').get('vitest') as { cnt: number };
+    expect(count.cnt).toBeGreaterThan(10);
+  });
+
+  it('includes sections from subdirectories', () => {
+    const row = db.prepare(
+      "SELECT COUNT(*) as cnt FROM sections WHERE language = 'vitest' AND canonical_url LIKE '%/guide/%'"
+    ).get() as { cnt: number };
+    expect(row.cnt).toBeGreaterThan(0);
+  });
+
+  it('builds correct canonical URLs (no .html suffix)', () => {
+    const rows = db.prepare(
+      "SELECT canonical_url FROM sections WHERE language = 'vitest' LIMIT 20"
+    ).all() as { canonical_url: string }[];
+
+    for (const row of rows) {
+      expect(row.canonical_url).toMatch(/^https:\/\/vitest\.dev\//);
+      // VitePress clean URLs: no .html before #
+      expect(row.canonical_url).not.toMatch(/\.html#/);
+    }
+  });
+
+  it('search finds vitest-specific content', () => {
+    const queries = new DatabaseQueries(db);
+    const results = queries.searchSections({ query: 'mock', language: 'vitest', limit: 10 });
+    expect(results.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **Recursive GitHub directory exploration**: `recursiveListMarkdownFiles()` enables ingesting docs from nested subdirectories (e.g., Vitest's `docs/guide/browser/`)
- **Generic DocConfig extensions**: `excludePaths` (skip non-doc dirs like `.vitepress`), `urlSuffix` (VitePress clean URLs), `chapterPattern` (configurable TOC link matching)
- **Vitest documentation config**: 189 markdown files, ~1587 sections indexed from `vitest-dev/vitest`

## Changes
| File | Change |
|------|--------|
| `src/config/languages.ts` | `excludePaths`, `urlSuffix` in DocConfig; Vitest config; explicit `chapterPattern` for Java |
| `src/ingestion/fetcher.ts` | `recursiveListMarkdownFiles()`, configurable `chapterPattern` |
| `src/ingestion/normalizer.ts` | `urlSuffix` support in canonical URL builder |
| `src/ingestion/index.ts` | Pass `urlSuffix` to normalizer |
| `tests/vitest-config.test.ts` | 6 unit tests (config, urlSuffix, canonical URLs) |
| `tests/vitest-ingestion.test.ts` | 4 integration tests (ingestion, subdirs, URLs, search) |
| `tests/language-config.test.ts` | Updated for 5 languages |
| `CLAUDE.md` | M6 milestone |
| `docs/03-config.md` | New fields, Vitest example, updated architecture |

## Test plan
- [x] 108 unit tests pass (`npx vitest run --exclude vitest-ingestion`)
- [x] Integration test verified: 189 files fetched, 1587 sections indexed
- [x] Canonical URLs use VitePress clean format (`https://vitest.dev/guide/mocking#mock-timers`)
- [x] `npm run ingest -- --language vitest` on fresh DB
- [x] Existing languages regression: `npm run ingest -- --language go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)