### PR TITLE
feat: M6 Vitest docs + M7 external config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
-data/
+data/*
+!data/sources.json
 *.db
 *.db-shm
 *.db-wal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,160 +2,68 @@
 
 ## Overview
 プログラミング言語仕様をインデックス化し、MCP経由で検索・引用を提供するサーバ。
-- **M1完了**: Go仕様 + stdio MCPサーバ + SQLite/FTS5
-- **M2完了**: Citation precision (diff re-index, source_policy, snippet, section_id stability)
-- **M3完了**: build_learning_plan tool (週間学習プラン自動生成)
-- **M4完了**: 多言語対応 (Go, Java, Rust, TypeScript)
-- **M5完了**: NFR堅牢化 (構造化ログ, retry/timeout, ETag, disk cache, 部分失敗回復, adaptive rate limiting)
-- **M6完了**: Vitest ドキュメント対応 + 汎用IT技術ドキュメント取り込み (再帰ディレクトリ探索, excludePaths, urlSuffix, chapterPattern汎化)
-- **M7完了**: 外部設定ファイル (`data/sources.json`) + DocSource 統一モデル (コード変更不要で新ドキュメント追加可能)
-- ~3,900セクション indexed (Go 162, Java 575, Rust 1401, TypeScript 178, Vitest ~1587)、5 MCP tools稼働、142+ tests
+- **M1〜M5完了**: Go/Java/Rust/TypeScript仕様 + SQLite/FTS5 + 構造化ログ/retry/cache/rate limiting
+- **M6完了**: Vitest ドキュメント対応 + 汎用IT技術ドキュメント取り込み
+- **M7完了**: 外部設定ファイル (`data/sources.json`) — コード変更不要で新ドキュメント追加可能
+- ~3,900セクション indexed、5 MCP tools稼働、142+ tests
 
 ## Tech Stack
 - TypeScript (ES modules, `"type": "module"`, `"module": "Node16"`)
-- `@modelcontextprotocol/sdk` v1.26.0 (Server + setRequestHandler)
-- `better-sqlite3` + FTS5
-- `cheerio` v1.x (HTML解析 — `Element`型は未export、`elem.tagName`直接参照)
-- `zod` (入力バリデーション)
+- `@modelcontextprotocol/sdk` v1.26.0 + `better-sqlite3` (FTS5) + `cheerio` v1.x + `zod`
 - stdio トランスポート
 
 ## Critical Rules
-- **`console.log` 厳禁** — stdoutはJSON-RPC通信専用。ログは構造化ロガー (`createLogger`) 経由で stderr 出力
+- **`console.log` 厳禁** — stdoutはJSON-RPC通信専用。ログは `createLogger()` 経由で stderr
 - **Tool結果は `{ content: [{ type: "text", text: JSON.stringify(data) }] }` 形式**
 - **FTS5同期はトリガーで自動化** — INSERT/UPDATE/DELETEで fts_sections が自動更新
 - **差分更新は `content_hash` 比較** — upsert前にハッシュ比較、変更時のみ更新
 
 ## File Structure
 ```
-data/
-├── sources.json         # External doc source config (add entries here, no rebuild needed)
-├── langspec.db          # SQLite database
-└── cache/               # ETag disk cache
+data/sources.json              # Doc source config (add entries here, no rebuild needed)
 src/
-├── index.ts             # CLI: ingest / serve (--language flag, LOG_LEVEL)
-├── server.ts            # MCP Server + tool registration
-├── types.ts             # TypeScript types + Zod schemas (FetchOutcome etc.)
+├── index.ts                   # CLI: ingest / serve
+├── server.ts                  # MCP Server + tool registration
+├── types.ts                   # Types + Zod schemas
 ├── config/
-│   ├── languages.ts     # LanguageConfig registry (lazy-loads from sources.json)
-│   ├── doc-source.ts    # DocSource type + Zod schema + resolveDocSource()
-│   └── source-loader.ts # loadSources() — reads & validates sources.json
-├── db/
-│   ├── schema.ts        # DB init + migrations
-│   └── queries.ts       # DatabaseQueries + extractRelevantSnippet()
+│   ├── languages.ts           # LanguageConfig registry (lazy-loads from sources.json)
+│   ├── doc-source.ts          # DocSource type + Zod + resolveDocSource()
+│   └── source-loader.ts       # loadSources() — reads & validates sources.json
+├── db/{schema,queries}.ts     # DB init + migrations, queries + snippet extraction
 ├── ingestion/
-│   ├── index.ts         # Pipeline orchestrator (diff report, partial failure)
-│   ├── fetcher.ts       # HTTP fetch (retry, cache, ETag, adaptive rate limit)
-│   ├── parser.ts        # HTML/Markdown → Section[] (cheerio, stableId)
-│   └── normalizer.ts    # Normalize + sourcePolicy + excerpt
-├── lib/
-│   ├── logger.ts        # Structured JSON logger (LOG_LEVEL, stderr)
-│   ├── retry.ts         # withRetry + FetchError + parseRetryAfter
-│   └── cache.ts         # DiskCache (ETag meta + content files)
-└── tools/
-    ├── list-languages.ts
-    ├── list-versions.ts
-    ├── search-spec.ts
-    ├── get-section.ts
-    └── build-learning-plan.ts
+│   ├── index.ts               # Pipeline orchestrator (diff report, partial failure)
+│   ├── fetcher.ts             # HTTP fetch (retry, cache, ETag, adaptive rate limit)
+│   ├── parser.ts              # HTML/Markdown → Section[]
+│   └── normalizer.ts          # Normalize + sourcePolicy + excerpt
+├── lib/{logger,retry,cache}.ts  # Structured logger, withRetry, DiskCache
+└── tools/                     # list-languages, list-versions, search-spec, get-section, build-learning-plan
 ```
 
 ## Key Patterns
-
-### External Config (M7)
-- ドキュメントソースは `data/sources.json` で定義（コード修正・再ビルド不要）
-- `DocSource` 統一モデル: `url` or `github` を指定、`fetchStrategy` は自動推論
-- `resolveDocSource()`: DocSource → DocConfig 変換（純粋関数）
-- `loadSources()`: JSON 読み込み → Zod バリデーション → LanguageConfig[] 生成
-- 新ソース追加: `data/sources.json` にエントリ追加 → `npm run ingest -- --language <name>`
-
-### Diff-based Re-index
-- `content_hash` (SHA-256) で各セクションの変更を検出
-- upsert結果: `inserted` / `updated` / `unchanged` で差分レポート出力
-
-### Section ID Stability
-- HTML見出しに `id` 属性がある場合はそのまま使用
-- `id` 無しの見出しには `stableId` (テキストベースのハッシュ) でフォールバック
-
-### Snippet Extraction
-- FTS5 content-sync mode では `snippet()` 関数が使用不可
-- `extractRelevantSnippet()`: クエリトークンの初出位置を中心にウィンドウ抽出
-
-### Source Policy
-- `normalizer.ts` で言語ごとの正規化ルール (URL構築、メタデータ付与) を管理
-
-### Structured Logging (M5)
-- `createLogger(component)` で JSON Lines を stderr 出力
-- `LOG_LEVEL` 環境変数: `debug` / `info` (default) / `warn` / `error`
-- `process.stderr.write()` で直接出力（`console.error` は使用しない）
-
-### Retry + Timeout (M5)
-- `withRetry(fn, opts)`: maxRetries=3, exponential backoff + ±25% jitter
-- `AbortSignal.timeout(30_000)` で全 fetch に 30 秒タイムアウト
-- `FetchError` クラス: url, status, retryAfter プロパティ
-- Retryable: 429, 500-599, TypeError (DNS/接続エラー)
-
-### ETag + Disk Cache (M5)
-- `fetchUrl()` が `If-None-Match` ヘッダーで条件付きリクエスト
-- 304 応答時はパース省略（single-html の場合は全体スキップ）
-- `DiskCache`: `data/cache/{lang}/{doc}/{url-sha256-16hex}.html` + `.meta.json`
-- キャッシュ ETag でページ単位の条件付きリクエスト
-
-### Partial Failure Recovery (M5)
-- `FetchOutcome` 型: `{ results, errors, summary: {total, fetched, cached, failed} }`
-- マルチページ取得で一部失敗しても残りを処理継続
-- 全失敗のみエラー throw、部分失敗は warn ログ + 処理継続
-
-### Adaptive Rate Limiting (M5)
-- 429 受信時にバッチ内の `delayMs` を動的に増加
-- `Retry-After` ヘッダー値を使用、無ければ倍増（上限 10 秒）
-
-## Documentation
-`docs/` にアーキテクチャ解説ドキュメント（日本語）を格納。初心者向けに設計〜実装を7章構成で解説。
-- `docs/README.md` — 目次・読み方ガイド・全体図
-- `docs/01-overview.md` — MCP概要と2つのコマンド
-- `docs/02-typescript-basics.md` — TS プロジェクト構成・ビルド
-- `docs/03-config.md` — 言語設定レジストリ・FetchStrategy
-- `docs/04-ingestion-pipeline.md` — 取り込みパイプライン全工程
-- `docs/05-database.md` — SQLite + FTS5 設計
-- `docs/06-mcp-server.md` — MCPサーバ・ツール実装
-- `docs/07-reliability.md` — ログ・リトライ・キャッシュ・レート制限
+- **External Config**: `data/sources.json` でソース定義 → `fetchStrategy` 自動推論 → 詳細は [docs/03-config.md](docs/03-config.md)
+- **Diff Re-index**: `content_hash` (SHA-256) で変更検出、`inserted`/`updated`/`unchanged` レポート
+- **Section ID**: HTML見出しの `id` 属性優先、無ければ `stableId` (テキストハッシュ) フォールバック
+- **Snippet**: FTS5 `snippet()` 使用不可のため `extractRelevantSnippet()` でクエリトークン中心抽出
+- **Source Policy**: `excerpt_only` (著作権保護) / `local_fulltext_ok` (OSS全文提供)
+- **M5 信頼性パターン**: 構造化ログ, retry/timeout, ETag/disk cache, 部分失敗回復, adaptive rate limiting → 詳細は [docs/07-reliability.md](docs/07-reliability.md)
 
 ## Build & Run
 ```bash
 npm run build                              # TypeScript compile
-npm run ingest                             # Fetch & index Go spec
-npm run ingest -- --language go            # Language指定
-npm run ingest -- --language all           # 全言語
+npm run ingest -- --language go            # Language指定 ingest
+npm run ingest -- --language all           # 全言語 ingest
 npm run serve                              # Start MCP server (stdio)
 LOG_LEVEL=debug npm run ingest -- --language go  # Debug ログ出力
 ```
+
+## Documentation
+アーキテクチャ解説は [docs/README.md](docs/README.md) を参照（7章構成、日本語）。
 
 ## Commit Convention
 - feat: / fix: / refactor: / docs: / test: prefix
 - 日本語OK、ただしコミットメッセージは英語
 
 ## Git Workflow
-
-### Git Flow ブランチモデル
-- **`main`** — 本番リリース用。直接コミット禁止
-- **`develop`** — 統合ブランチ。feature ブランチのマージ先
-- **`feature/<issue番号>-<slug>`** — 機能開発。develop から分岐、develop へマージ
-- **`release/<version>`** — リリース準備。develop → main へマージ
-- **`hotfix/<slug>`** — 緊急修正。main から分岐、main + develop へマージ
-
-### 開発フロー
-1. **Plan mode** で計画立案 → タスクごとに GitHub Issue を作成 (`github-issues` スキル or `refine-issue` エージェント)
-2. **Issue ごとに feature ブランチ作成** — `git-flow-manager` エージェントを使用
-3. **実装 → テスト → コミット** — develop へ PR 作成
-4. **PR マージ** — squash or merge commit
-
-### スキル/エージェント使い分け
-- **`git-advanced-workflows` スキル** — rebase, cherry-pick, bisect, worktree, reflog 等の高度なGit操作時に参照
-- **`git-flow-manager` エージェント** — feature/release/hotfix ブランチの作成・マージ・PR生成時に使用 (Task tool, subagent_type=git-flow-manager)
-- **`github-issues` スキル** — Issue 作成・更新・ラベル管理
-- **`refine-issue` エージェント** — 要件を AC/技術考慮/エッジケース/NFR に整理
-
-### トリガー
-- PreToolUse フック (`git-skill-reminder.sh`) が git コマンドを検出し、適切なスキル/エージェントの使用をリマインド
-- ブランチ作成・マージ → git-flow-manager
-- rebase/cherry-pick/bisect/stash/reflog → git-advanced-workflows
+- **Git Flow**: `main`(本番) / `develop`(統合) / `feature/` / `release/` / `hotfix/`
+- **開発フロー**: Plan mode → Issue作成 → feature branch → PR to develop
+- 詳細（スキル/エージェント使い分け、トリガー）は [docs/git-workflow.md](docs/git-workflow.md) を参照

--- a/data/sources.json
+++ b/data/sources.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "go",
+    "displayName": "Go",
+    "doc": "go-spec",
+    "docDisplayName": "The Go Programming Language Specification",
+    "url": "https://go.dev/ref/spec",
+    "sourcePolicy": "excerpt_only"
+  },
+  {
+    "name": "java",
+    "displayName": "Java",
+    "doc": "jls",
+    "docDisplayName": "The Java Language Specification (SE21)",
+    "url": "https://docs.oracle.com/javase/specs/jls/se21/html/index.html",
+    "chapterPattern": "^jls-\\d+\\.html$",
+    "sourcePolicy": "excerpt_only",
+    "notes": "Oracle著作権のためexcerpt_only"
+  },
+  {
+    "name": "rust",
+    "displayName": "Rust",
+    "doc": "rust-reference",
+    "docDisplayName": "The Rust Reference",
+    "github": "rust-lang/reference",
+    "path": "src",
+    "manifestFile": "SUMMARY.md",
+    "canonicalBaseUrl": "https://doc.rust-lang.org/reference"
+  },
+  {
+    "name": "typescript",
+    "displayName": "TypeScript",
+    "doc": "ts-handbook",
+    "docDisplayName": "TypeScript Handbook",
+    "github": "microsoft/TypeScript-Website",
+    "path": "packages/documentation/copy/en/handbook-v2",
+    "notes": "Handbookは完全な仕様書ではない（公式明記）"
+  },
+  {
+    "name": "vitest",
+    "displayName": "Vitest",
+    "doc": "vitest-docs",
+    "docDisplayName": "Vitest Documentation",
+    "github": "vitest-dev/vitest",
+    "path": "docs",
+    "excludePaths": [".vitepress", "team", "public"],
+    "canonicalBaseUrl": "https://vitest.dev",
+    "urlSuffix": ""
+  }
+]

--- a/docs/03-config.md
+++ b/docs/03-config.md
@@ -2,31 +2,136 @@
 
 ## このドキュメントで学ぶこと
 
-- `LanguageConfig` と `DocConfig` の構造
+- 外部設定ファイル `data/sources.json` によるドキュメントソース管理
+- `DocSource` 統一モデルと自動推論の仕組み
+- `LanguageConfig` と `DocConfig` の内部構造
 - 3つの取得戦略（FetchStrategy）の違い
 - `sourcePolicy` による著作権保護の仕組み
-- 新しい言語・フレームワークを追加する方法
+- 新しい言語・フレームワークを追加する方法（再ビルド不要）
 - `excludePaths` / `urlSuffix` による汎用ドキュメント対応
 
-## 設定レジストリとは
+## 外部設定ファイル: `data/sources.json`
 
-このプロジェクトは複数のプログラミング言語の仕様書を扱います。しかし、言語ごとに仕様書の公開形式が異なります:
+M7 で導入された外部設定ファイルにより、新しいドキュメントソースの追加に **コード修正や再ビルドが不要** になりました。
 
-- Go: 1ページのHTMLに全仕様が載っている
-- Java: 目次ページ + 複数の章ページに分かれている
-- Rust: GitHubリポジトリにMarkdownファイルが並んでいる
-- Vitest: GitHubリポジトリにネストされたサブディレクトリ構造のMarkdown
+```
+data/sources.json (シンプルな統一モデル)
+        │
+        v
+  DocSource → DocConfig リゾルバ
+  - url / github から fetchStrategy を自動推論
+  - デフォルト値の適用
+  - RegExp 文字列→オブジェクト変換
+        │
+        v
+  DocConfig (内部型)
+  - fetcher, parser, normalizer がそのまま使用
+```
 
-これらの違いを吸収するために、各言語の設定を1つの配列 `LANGUAGES` に集約しています。
+**対応コード**:
+- `data/sources.json` — 設定ファイル
+- `src/config/doc-source.ts` — DocSource 型 + Zod スキーマ + リゾルバ
+- `src/config/source-loader.ts` — JSON 読み込み + バリデーション
+- `src/config/languages.ts` — 遅延ロードでの LanguageConfig 提供
 
-**対応コード**: `src/config/languages.ts`
+## DocSource — 統一モデル
 
-## データ構造
+`DocSource` は外部設定ファイルの1エントリを表す統一モデルです。`fetchStrategy` の指定は不要で、`url` か `github` の指定パターンから自動推論されます。
+
+```typescript
+// src/config/doc-source.ts
+interface DocSource {
+  // === 必須 ===
+  name: string;           // DB の language キー (例: "vitest")
+  displayName: string;    // 表示名 (例: "Vitest")
+
+  // === ソース (url か github のどちらか一方) ===
+  url?: string;           // HTML ソース → single-html or multi-html-toc
+  github?: string;        // "owner/repo" → github-markdown
+
+  // === オプション ===
+  doc?: string;           // ドキュメント識別子 (デフォルト: name + "-docs")
+  docDisplayName?: string;
+  sourcePolicy?: string;  // デフォルト: github→local_fulltext_ok, url→excerpt_only
+  headingSelectors?: string;  // デフォルト: "h2, h3, h4"
+  notes?: string;
+
+  // === multi-html-toc 用 ===
+  chapterPattern?: string;  // 文字列 → new RegExp() で変換
+
+  // === github-markdown 用 ===
+  path?: string;            // リポジトリ内パス (デフォルト: "")
+  manifestFile?: string;    // 例: "SUMMARY.md"
+  excludePaths?: string[];  // 除外ディレクトリ
+
+  // === URL 構築 ===
+  canonicalBaseUrl?: string;
+  urlSuffix?: string;       // デフォルト: ".html"。VitePress は ""
+}
+```
+
+### 戦略の自動推論ルール
+
+| 条件 | 推論される fetchStrategy |
+|------|------------------------|
+| `github` あり | `github-markdown` |
+| `url` + `chapterPattern` あり | `multi-html-toc` |
+| `url` のみ | `single-html` |
+
+### デフォルト値
+
+| フィールド | デフォルト値 |
+|-----------|------------|
+| `doc` | `${name}-docs` |
+| `sourcePolicy` | github → `local_fulltext_ok`, url → `excerpt_only` |
+| `headingSelectors` | `"h2, h3, h4"` |
+| `path` (github) | `""` |
+| `canonicalBaseUrl` (single-html) | `url` そのまま |
+| `canonicalBaseUrl` (multi-html-toc) | `url` のディレクトリ部分 |
+
+## data/sources.json の例
+
+```json
+[
+  {
+    "name": "go",
+    "displayName": "Go",
+    "doc": "go-spec",
+    "docDisplayName": "The Go Programming Language Specification",
+    "url": "https://go.dev/ref/spec",
+    "sourcePolicy": "excerpt_only"
+  },
+  {
+    "name": "java",
+    "displayName": "Java",
+    "doc": "jls",
+    "docDisplayName": "The Java Language Specification (SE21)",
+    "url": "https://docs.oracle.com/javase/specs/jls/se21/html/index.html",
+    "chapterPattern": "^jls-\\d+\\.html$",
+    "sourcePolicy": "excerpt_only"
+  },
+  {
+    "name": "vitest",
+    "displayName": "Vitest",
+    "doc": "vitest-docs",
+    "docDisplayName": "Vitest Documentation",
+    "github": "vitest-dev/vitest",
+    "path": "docs",
+    "excludePaths": [".vitepress", "team", "public"],
+    "canonicalBaseUrl": "https://vitest.dev",
+    "urlSuffix": ""
+  }
+]
+```
+
+## 設定レジストリの内部構造
+
+`sources.json` から読み込まれた設定は、内部で `LanguageConfig` / `DocConfig` に変換されます。
 
 ### LanguageConfig — 言語の定義
 
 ```typescript
-// src/config/languages.ts:24-28
+// src/config/languages.ts
 interface LanguageConfig {
   language: string;       // 内部キー（例: 'go', 'java'）
   displayName: string;    // 表示名（例: 'Go', 'Java'）
@@ -39,7 +144,7 @@ interface LanguageConfig {
 ### DocConfig — ドキュメントの定義
 
 ```typescript
-// src/config/languages.ts:3-24
+// src/config/languages.ts
 interface DocConfig {
   doc: string;                // ドキュメント識別子（例: 'go-spec'）
   displayName: string;        // 表示名
@@ -59,15 +164,29 @@ interface DocConfig {
   githubPath?: string;        // ファイルパス
   manifestFile?: string;      // マニフェストファイル（例: SUMMARY.md）
   canonicalBaseUrl?: string;  // 正規化URLのベース
-  excludePaths?: string[];    // 再帰探索で除外するパス（例: ['.vitepress', 'team']）
+  excludePaths?: string[];    // 再帰探索で除外するパス
   urlSuffix?: string;         // URL末尾（デフォルト '.html'、VitePress は ''）
+}
+```
+
+### 遅延ロード
+
+`src/config/languages.ts` は `data/sources.json` を **遅延ロード** します。最初にアクセスされた時点で1回だけ読み込み・パース・バリデーションが行われます:
+
+```typescript
+// src/config/languages.ts (概要)
+let _languages: LanguageConfig[] | null = null;
+
+function ensureLoaded(): void {
+  if (!_languages) {
+    _languages = loadSources();  // sources.json → LanguageConfig[]
+  }
 }
 ```
 
 ## 3つの取得戦略（FetchStrategy）
 
 ```typescript
-// src/config/languages.ts:1
 type FetchStrategy = 'single-html' | 'multi-html-toc' | 'github-markdown';
 ```
 
@@ -90,24 +209,7 @@ type FetchStrategy = 'single-html' | 'multi-html-toc' | 'github-markdown';
 
 **使用言語**: Go
 
-最もシンプルな戦略です。1つのURLにアクセスするだけで仕様書全体が手に入ります。
-
-```typescript
-// src/config/languages.ts:32-44 (Go の設定)
-{
-  language: 'go',
-  displayName: 'Go',
-  docs: [{
-    doc: 'go-spec',
-    displayName: 'The Go Programming Language Specification',
-    fetchStrategy: 'single-html',
-    url: 'https://go.dev/ref/spec',
-    headingSelectors: 'h2, h3, h4',
-    sourcePolicy: 'excerpt_only',
-    canonicalBaseUrl: 'https://go.dev/ref/spec',
-  }],
-}
-```
+最もシンプルな戦略です。1つのURLにアクセスするだけで仕様書全体が手に入ります。`url` フィールドのみ指定で自動推論されます。
 
 ### 2. `multi-html-toc` — 目次 + 複数章
 
@@ -127,24 +229,7 @@ type FetchStrategy = 'single-html' | 'multi-html-toc' | 'github-markdown';
 
 **使用言語**: Java (JLS)
 
-まず目次ページ（`index.html`）を取得し、そこからリンクを抽出して各章を順次ダウンロードします。サーバに負荷をかけないよう、リクエスト間に遅延（200ms）を入れています。
-
-```typescript
-// src/config/languages.ts:48-59 (Java の設定)
-{
-  language: 'java',
-  displayName: 'Java',
-  docs: [{
-    doc: 'jls',
-    displayName: 'The Java Language Specification (SE21)',
-    fetchStrategy: 'multi-html-toc',
-    indexUrl: 'https://docs.oracle.com/javase/specs/jls/se21/html/index.html',
-    headingSelectors: 'h2, h3, h4',
-    sourcePolicy: 'excerpt_only',
-    canonicalBaseUrl: 'https://docs.oracle.com/javase/specs/jls/se21/html',
-  }],
-}
-```
+`url` + `chapterPattern` の組み合わせで自動推論されます。
 
 ### 3. `github-markdown` — GitHubリポジトリのMarkdown
 
@@ -163,55 +248,12 @@ type FetchStrategy = 'single-html' | 'multi-html-toc' | 'github-markdown';
 
 **使用言語**: Rust, TypeScript, Vitest
 
-GitHubリポジトリ内のMarkdownファイル群を取得します。ファイル一覧の取得方法は2通り:
+`github` フィールドの指定で自動推論されます。ファイル一覧の取得方法は2通り:
 
 1. **マニフェストファイル方式** (`manifestFile` 指定時): `SUMMARY.md` などのマニフェストからファイル一覧を取得（Rust）
 2. **再帰的ディレクトリ探索** (`manifestFile` 未指定時): GitHub Contents API でディレクトリを再帰的に探索し、`.md` ファイルを収集。`excludePaths` で不要なディレクトリを除外可能（TypeScript, Vitest）
 
-```typescript
-// Rust の設定（マニフェスト方式）
-{
-  language: 'rust',
-  displayName: 'Rust',
-  docs: [{
-    doc: 'rust-reference',
-    displayName: 'The Rust Reference',
-    fetchStrategy: 'github-markdown',
-    githubOwner: 'rust-lang',
-    githubRepo: 'reference',
-    githubPath: 'src',
-    manifestFile: 'SUMMARY.md',
-    sourcePolicy: 'local_fulltext_ok',
-    canonicalBaseUrl: 'https://doc.rust-lang.org/reference',
-  }],
-}
-```
-
-```typescript
-// Vitest の設定（再帰的ディレクトリ探索 + VitePress clean URLs）
-{
-  language: 'vitest',
-  displayName: 'Vitest',
-  docs: [{
-    doc: 'vitest-docs',
-    displayName: 'Vitest Documentation',
-    fetchStrategy: 'github-markdown',
-    githubOwner: 'vitest-dev',
-    githubRepo: 'vitest',
-    githubPath: 'docs',
-    sourcePolicy: 'local_fulltext_ok',
-    canonicalBaseUrl: 'https://vitest.dev',
-    excludePaths: ['.vitepress', 'team', 'public'],  // ビルド設定・チームページ・静的アセットを除外
-    urlSuffix: '',                           // VitePress clean URLs (.html不要)
-  }],
-}
-```
-
 ## sourcePolicy — 著作権保護
-
-```typescript
-sourcePolicy: 'excerpt_only' | 'local_fulltext_ok'
-```
 
 | ポリシー | 意味 | 対象 |
 |---------|------|------|
@@ -220,71 +262,54 @@ sourcePolicy: 'excerpt_only' | 'local_fulltext_ok'
 
 Go や Java の仕様書は著作権で保護されているため、AIに全文を渡すことは避け、抜粋と公式サイトへのリンクを提供します。Rust や TypeScript のドキュメントはオープンソースライセンスなので全文提供が可能です。
 
-この値は `get_section` ツールで使われます（`src/tools/get-section.ts:28`）:
-
-```typescript
-const fulltextAvailable = section.source_policy === 'local_fulltext_ok';
-// fulltext_available が false なら excerpt のみ返す
-```
-
 ## 新しい言語・フレームワークを追加する方法
 
-新しいドキュメントを追加するには、`src/config/languages.ts` の `LANGUAGES` 配列に1つエントリを追加するだけです。`language` フィールドはプログラミング言語だけでなく、フレームワークやツール（Vitest, Vite, React 等）にも使えます。
+新しいドキュメントを追加するには、`data/sources.json` に1つエントリを追加するだけです。**コード修正も再ビルドも不要**です。
 
-### 例1: Python（single-html）
+### 例1: Python（1ページHTMLドキュメント）
 
-```typescript
+```json
 {
-  language: 'python',
-  displayName: 'Python',
-  docs: [{
-    doc: 'python-reference',
-    displayName: 'The Python Language Reference',
-    fetchStrategy: 'single-html',
-    url: 'https://docs.python.org/3/reference/index.html',
-    headingSelectors: 'h1, h2, h3',
-    sourcePolicy: 'excerpt_only',
-    canonicalBaseUrl: 'https://docs.python.org/3/reference',
-  }],
+  "name": "python",
+  "displayName": "Python",
+  "doc": "python-reference",
+  "docDisplayName": "The Python Language Reference",
+  "url": "https://docs.python.org/3/reference/index.html",
+  "headingSelectors": "h1, h2, h3",
+  "sourcePolicy": "excerpt_only"
 }
 ```
 
-### 例2: Vite（github-markdown + VitePress clean URLs）
+### 例2: Vite（GitHub + VitePress clean URLs）
 
-```typescript
+```json
 {
-  language: 'vite',
-  displayName: 'Vite',
-  docs: [{
-    doc: 'vite-docs',
-    displayName: 'Vite Documentation',
-    fetchStrategy: 'github-markdown',
-    githubOwner: 'vitejs',
-    githubRepo: 'vite',
-    githubPath: 'docs',
-    sourcePolicy: 'local_fulltext_ok',
-    canonicalBaseUrl: 'https://vite.dev',
-    excludePaths: ['.vitepress', 'blog'],
-    urlSuffix: '',   // VitePress clean URLs
-  }],
+  "name": "vite",
+  "displayName": "Vite",
+  "doc": "vite-docs",
+  "docDisplayName": "Vite Documentation",
+  "github": "vitejs/vite",
+  "path": "docs",
+  "excludePaths": [".vitepress", "blog"],
+  "canonicalBaseUrl": "https://vite.dev",
+  "urlSuffix": ""
 }
 ```
 
 ### 追加後の手順
 
 ```bash
-npm run build                         # TypeScriptを再コンパイル
+# 再ビルド不要！ そのままインジェスト実行
 npm run ingest -- --language vite     # 新ドキュメントを取り込み
 ```
 
-これだけで、MCPサーバの `list_languages` ツールに新しいエントリが表示され、`search_spec` で検索できるようになります。コードの他の部分を変更する必要はありません。
+これだけで、MCPサーバの `list_languages` ツールに新しいエントリが表示され、`search_spec` で検索できるようになります。
 
 ## ユーティリティ関数
 
-`src/config/languages.ts` は設定データだけでなく、それを参照するための関数も提供します:
+`src/config/languages.ts` は設定データを参照するための関数を提供します:
 
 ```typescript
-// src/config/languages.ts:102-128
 getLanguageConfig('go')       // → LanguageConfig（言語全体の設定）
 getDocConfig('go')            // → DocConfig（最初のドキュメント設定）
 getDocConfig('go', 'go-spec') // → DocConfig（特定ドキュメント）
@@ -292,14 +317,15 @@ getSupportedLanguages()       // → ['go', 'java', 'rust', 'typescript', 'vites
 getAllLanguageConfigs()        // → LanguageConfig[] (全設定)
 ```
 
-`getSupportedLanguages()` は MCP ツールの `enum` として使われ、AIが「どの言語を指定できるか」を知るための情報源になります（`src/server.ts:31`）。
+`getSupportedLanguages()` は MCP ツールの `enum` として使われ、AIが「どの言語を指定できるか」を知るための情報源になります（`src/server.ts`）。
 
 ## まとめ
 
-- 言語設定は `LANGUAGES` 配列に集約されている
+- ドキュメントソースは `data/sources.json` で外部管理（コード変更・再ビルド不要）
+- `DocSource` 統一モデルで `url` / `github` を指定するだけで `fetchStrategy` を自動推論
 - 3つの取得戦略で異なる形式の仕様書・ドキュメントに対応
 - `sourcePolicy` で著作権保護レベルを制御
 - `excludePaths` で不要なディレクトリを除外、`urlSuffix` で URL 形式を制御
-- 新しい言語やフレームワークの追加は配列に1エントリ追加するだけ
+- 新しい言語やフレームワークの追加は JSON に1エントリ追加 → `npm run ingest` するだけ
 
 次のドキュメント [04-ingestion-pipeline.md](./04-ingestion-pipeline.md) では、データ取り込みパイプラインの詳細を解説します。

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -1,0 +1,31 @@
+# Git Workflow
+
+## Git Flow ブランチモデル
+
+- **`main`** — 本番リリース用。直接コミット禁止
+- **`develop`** — 統合ブランチ。feature ブランチのマージ先
+- **`feature/<issue番号>-<slug>`** — 機能開発。develop から分岐、develop へマージ
+- **`release/<version>`** — リリース準備。develop → main へマージ
+- **`hotfix/<slug>`** — 緊急修正。main から分岐、main + develop へマージ
+
+## 開発フロー
+
+1. **Plan mode** で計画立案 → タスクごとに GitHub Issue を作成 (`github-issues` スキル or `refine-issue` エージェント)
+2. **Issue ごとに feature ブランチ作成** — `git-flow-manager` エージェントを使用
+3. **実装 → テスト → コミット** — develop へ PR 作成
+4. **PR マージ** — squash or merge commit
+
+## スキル/エージェント使い分け
+
+| ツール | 用途 |
+|--------|------|
+| **`git-advanced-workflows` スキル** | rebase, cherry-pick, bisect, worktree, reflog 等の高度なGit操作時に参照 |
+| **`git-flow-manager` エージェント** | feature/release/hotfix ブランチの作成・マージ・PR生成 (Task tool, subagent_type=git-flow-manager) |
+| **`github-issues` スキル** | Issue 作成・更新・ラベル管理 |
+| **`refine-issue` エージェント** | 要件を AC/技術考慮/エッジケース/NFR に整理 |
+
+## トリガー
+
+- PreToolUse フック (`git-skill-reminder.sh`) が git コマンドを検出し、適切なスキル/エージェントの使用をリマインド
+- ブランチ作成・マージ → git-flow-manager
+- rebase/cherry-pick/bisect/stash/reflog → git-advanced-workflows

--- a/src/config/doc-source.ts
+++ b/src/config/doc-source.ts
@@ -1,0 +1,170 @@
+import { z } from 'zod';
+import type { DocConfig, FetchStrategy, LanguageConfig } from './languages.js';
+
+// ========================================
+// DocSource — unified external config model
+// ========================================
+
+export interface DocSource {
+  name: string;
+  displayName: string;
+
+  // Source (exactly one of url or github)
+  url?: string;
+  github?: string;  // "owner/repo"
+
+  // Optional
+  doc?: string;
+  docDisplayName?: string;
+  sourcePolicy?: 'excerpt_only' | 'local_fulltext_ok';
+  headingSelectors?: string;
+  notes?: string;
+
+  // multi-html-toc
+  chapterPattern?: string;  // string → new RegExp()
+
+  // github-markdown
+  path?: string;
+  manifestFile?: string;
+  excludePaths?: string[];
+
+  // URL construction
+  canonicalBaseUrl?: string;
+  urlSuffix?: string;
+}
+
+// ========================================
+// Zod schema with validation
+// ========================================
+
+const githubPattern = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
+
+export const DocSourceSchema = z.object({
+  name: z.string().min(1),
+  displayName: z.string().min(1),
+
+  url: z.string().url().optional(),
+  github: z.string().regex(githubPattern, 'Must be "owner/repo" format').optional(),
+
+  doc: z.string().optional(),
+  docDisplayName: z.string().optional(),
+  sourcePolicy: z.enum(['excerpt_only', 'local_fulltext_ok']).optional(),
+  headingSelectors: z.string().optional(),
+  notes: z.string().optional(),
+
+  chapterPattern: z.string().optional(),
+
+  path: z.string().optional(),
+  manifestFile: z.string().optional(),
+  excludePaths: z.array(z.string()).optional(),
+
+  canonicalBaseUrl: z.string().url().optional(),
+  urlSuffix: z.string().optional(),
+}).refine(
+  (data) => (data.url != null) !== (data.github != null),
+  { message: 'Exactly one of "url" or "github" must be provided' },
+).refine(
+  (data) => {
+    if (data.chapterPattern) {
+      try {
+        new RegExp(data.chapterPattern);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  },
+  { message: 'chapterPattern must be a valid regular expression' },
+);
+
+// ========================================
+// Strategy inference
+// ========================================
+
+function inferStrategy(source: DocSource): FetchStrategy {
+  if (source.github) return 'github-markdown';
+  if (source.url && source.chapterPattern) return 'multi-html-toc';
+  return 'single-html';
+}
+
+// ========================================
+// Resolver: DocSource → LanguageConfig entry
+// ========================================
+
+export function resolveDocSource(source: DocSource): { language: string; docConfig: DocConfig } {
+  const strategy = inferStrategy(source);
+  const docSlug = source.doc ?? `${source.name}-docs`;
+
+  const docConfig: DocConfig = {
+    doc: docSlug,
+    displayName: source.docDisplayName ?? source.displayName,
+    fetchStrategy: strategy,
+    sourcePolicy: source.sourcePolicy ?? (strategy === 'github-markdown' ? 'local_fulltext_ok' : 'excerpt_only'),
+    headingSelectors: source.headingSelectors ?? 'h2, h3, h4',
+    notes: source.notes,
+  };
+
+  switch (strategy) {
+    case 'single-html': {
+      docConfig.url = source.url!;
+      docConfig.canonicalBaseUrl = source.canonicalBaseUrl ?? source.url!;
+      break;
+    }
+    case 'multi-html-toc': {
+      docConfig.indexUrl = source.url!;
+      docConfig.chapterPattern = new RegExp(source.chapterPattern!);
+      // Derive canonicalBaseUrl: strip filename from URL
+      const urlObj = new URL(source.url!);
+      const pathParts = urlObj.pathname.split('/');
+      pathParts.pop(); // remove filename (e.g., index.html)
+      urlObj.pathname = pathParts.join('/');
+      docConfig.canonicalBaseUrl = source.canonicalBaseUrl ?? urlObj.toString().replace(/\/$/, '');
+      break;
+    }
+    case 'github-markdown': {
+      const [owner, repo] = source.github!.split('/');
+      docConfig.githubOwner = owner;
+      docConfig.githubRepo = repo;
+      docConfig.githubPath = source.path ?? '';
+      if (source.manifestFile) docConfig.manifestFile = source.manifestFile;
+      if (source.canonicalBaseUrl) docConfig.canonicalBaseUrl = source.canonicalBaseUrl;
+      if (source.excludePaths) docConfig.excludePaths = source.excludePaths;
+      if (source.urlSuffix !== undefined) docConfig.urlSuffix = source.urlSuffix;
+      break;
+    }
+  }
+
+  return {
+    language: source.name,
+    docConfig,
+  };
+}
+
+// ========================================
+// Group resolved sources into LanguageConfig[]
+// ========================================
+
+export function groupByLanguage(
+  resolved: Array<{ language: string; docConfig: DocConfig }>,
+  sources: DocSource[],
+): LanguageConfig[] {
+  const map = new Map<string, LanguageConfig>();
+
+  for (let i = 0; i < resolved.length; i++) {
+    const { language, docConfig } = resolved[i];
+    const source = sources[i];
+    let entry = map.get(language);
+    if (!entry) {
+      entry = {
+        language,
+        displayName: source.displayName,
+        docs: [],
+      };
+      map.set(language, entry);
+    }
+    entry.docs.push(docConfig);
+  }
+
+  return Array.from(map.values());
+}

--- a/src/config/languages.ts
+++ b/src/config/languages.ts
@@ -1,3 +1,5 @@
+import { loadSources } from './source-loader.js';
+
 export type FetchStrategy = 'single-html' | 'multi-html-toc' | 'github-markdown';
 
 export interface DocConfig {
@@ -29,99 +31,23 @@ export interface LanguageConfig {
   docs: DocConfig[];
 }
 
-const LANGUAGES: LanguageConfig[] = [
-  {
-    language: 'go',
-    displayName: 'Go',
-    docs: [
-      {
-        doc: 'go-spec',
-        displayName: 'The Go Programming Language Specification',
-        fetchStrategy: 'single-html',
-        url: 'https://go.dev/ref/spec',
-        headingSelectors: 'h2, h3, h4',
-        sourcePolicy: 'excerpt_only',
-        canonicalBaseUrl: 'https://go.dev/ref/spec',
-      },
-    ],
-  },
-  {
-    language: 'java',
-    displayName: 'Java',
-    docs: [
-      {
-        doc: 'jls',
-        displayName: 'The Java Language Specification (SE21)',
-        fetchStrategy: 'multi-html-toc',
-        indexUrl: 'https://docs.oracle.com/javase/specs/jls/se21/html/index.html',
-        headingSelectors: 'h2, h3, h4',
-        sourcePolicy: 'excerpt_only',
-        canonicalBaseUrl: 'https://docs.oracle.com/javase/specs/jls/se21/html',
-        chapterPattern: /^jls-\d+\.html$/,
-        notes: 'Oracle著作権のためexcerpt_only',
-      },
-    ],
-  },
-  {
-    language: 'rust',
-    displayName: 'Rust',
-    docs: [
-      {
-        doc: 'rust-reference',
-        displayName: 'The Rust Reference',
-        fetchStrategy: 'github-markdown',
-        githubOwner: 'rust-lang',
-        githubRepo: 'reference',
-        githubPath: 'src',
-        manifestFile: 'SUMMARY.md',
-        sourcePolicy: 'local_fulltext_ok',
-        canonicalBaseUrl: 'https://doc.rust-lang.org/reference',
-      },
-    ],
-  },
-  {
-    language: 'typescript',
-    displayName: 'TypeScript',
-    docs: [
-      {
-        doc: 'ts-handbook',
-        displayName: 'TypeScript Handbook',
-        fetchStrategy: 'github-markdown',
-        githubOwner: 'microsoft',
-        githubRepo: 'TypeScript-Website',
-        githubPath: 'packages/documentation/copy/en/handbook-v2',
-        sourcePolicy: 'local_fulltext_ok',
-        notes: 'Handbookは完全な仕様書ではない（公式明記）',
-      },
-    ],
-  },
-  {
-    language: 'vitest',
-    displayName: 'Vitest',
-    docs: [
-      {
-        doc: 'vitest-docs',
-        displayName: 'Vitest Documentation',
-        fetchStrategy: 'github-markdown',
-        githubOwner: 'vitest-dev',
-        githubRepo: 'vitest',
-        githubPath: 'docs',
-        sourcePolicy: 'local_fulltext_ok',
-        canonicalBaseUrl: 'https://vitest.dev',
-        excludePaths: ['.vitepress', 'team', 'public'],
-        urlSuffix: '',
-      },
-    ],
-  },
-];
+// Lazy-loaded from data/sources.json
+let _languages: LanguageConfig[] | null = null;
+let _languageMap: Map<string, LanguageConfig> | null = null;
 
-const languageMap = new Map<string, LanguageConfig>();
-for (const lang of LANGUAGES) {
-  languageMap.set(lang.language, lang);
+function ensureLoaded(): void {
+  if (!_languages) {
+    _languages = loadSources();
+    _languageMap = new Map<string, LanguageConfig>();
+    for (const lang of _languages) {
+      _languageMap.set(lang.language, lang);
+    }
+  }
 }
 
 export function getLanguageConfig(language: string): LanguageConfig {
-  const config = languageMap.get(language);
+  ensureLoaded();
+  const config = _languageMap!.get(language);
   if (!config) {
     throw new Error(`Unknown language: ${language}. Supported: ${getSupportedLanguages().join(', ')}`);
   }
@@ -141,9 +67,11 @@ export function getDocConfig(language: string, doc?: string): DocConfig {
 }
 
 export function getSupportedLanguages(): string[] {
-  return LANGUAGES.map(l => l.language);
+  ensureLoaded();
+  return _languages!.map(l => l.language);
 }
 
 export function getAllLanguageConfigs(): LanguageConfig[] {
-  return LANGUAGES;
+  ensureLoaded();
+  return _languages!;
 }

--- a/src/config/source-loader.ts
+++ b/src/config/source-loader.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+import { DocSourceSchema, resolveDocSource, groupByLanguage } from './doc-source.js';
+import type { LanguageConfig } from './languages.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_SOURCES_PATH = resolve(__dirname, '../../data/sources.json');
+
+const DocSourceArraySchema = z.array(DocSourceSchema);
+
+export function loadSources(filePath?: string): LanguageConfig[] {
+  const sourcesPath = filePath ?? DEFAULT_SOURCES_PATH;
+
+  let raw: string;
+  try {
+    raw = readFileSync(sourcesPath, 'utf-8');
+  } catch (err) {
+    throw new Error(`Failed to read sources file: ${sourcesPath}: ${(err as Error).message}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Invalid JSON in sources file: ${sourcesPath}: ${(err as Error).message}`);
+  }
+
+  const result = DocSourceArraySchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues.map(i => `  - ${i.path.join('.')}: ${i.message}`).join('\n');
+    throw new Error(`Validation error in sources file:\n${issues}`);
+  }
+
+  const sources = result.data;
+
+  // Check for duplicate names
+  const seen = new Set<string>();
+  for (const source of sources) {
+    if (seen.has(source.name)) {
+      throw new Error(`Duplicate source name: "${source.name}" in ${sourcesPath}`);
+    }
+    seen.add(source.name);
+  }
+
+  const resolved = sources.map(s => resolveDocSource(s));
+  return groupByLanguage(resolved, sources);
+}

--- a/tests/doc-source.test.ts
+++ b/tests/doc-source.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'vitest';
+import { DocSourceSchema, resolveDocSource, groupByLanguage } from '../src/config/doc-source.js';
+import type { DocSource } from '../src/config/doc-source.js';
+
+// ========================================
+// Strategy auto-inference
+// ========================================
+
+describe('strategy auto-inference', () => {
+  it('github → github-markdown', () => {
+    const source: DocSource = {
+      name: 'test',
+      displayName: 'Test',
+      github: 'owner/repo',
+    };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.fetchStrategy).toBe('github-markdown');
+  });
+
+  it('url + chapterPattern → multi-html-toc', () => {
+    const source: DocSource = {
+      name: 'test',
+      displayName: 'Test',
+      url: 'https://example.com/docs/index.html',
+      chapterPattern: '^ch-\\d+\\.html$',
+    };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.fetchStrategy).toBe('multi-html-toc');
+  });
+
+  it('url only → single-html', () => {
+    const source: DocSource = {
+      name: 'test',
+      displayName: 'Test',
+      url: 'https://example.com/spec',
+    };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.fetchStrategy).toBe('single-html');
+  });
+});
+
+// ========================================
+// Existing 5 sources resolve correctly
+// ========================================
+
+describe('existing sources resolve correctly', () => {
+  it('Go → single-html with correct fields', () => {
+    const source: DocSource = {
+      name: 'go',
+      displayName: 'Go',
+      doc: 'go-spec',
+      docDisplayName: 'The Go Programming Language Specification',
+      url: 'https://go.dev/ref/spec',
+      sourcePolicy: 'excerpt_only',
+    };
+    const { language, docConfig } = resolveDocSource(source);
+    expect(language).toBe('go');
+    expect(docConfig.fetchStrategy).toBe('single-html');
+    expect(docConfig.doc).toBe('go-spec');
+    expect(docConfig.displayName).toBe('The Go Programming Language Specification');
+    expect(docConfig.url).toBe('https://go.dev/ref/spec');
+    expect(docConfig.sourcePolicy).toBe('excerpt_only');
+    expect(docConfig.canonicalBaseUrl).toBe('https://go.dev/ref/spec');
+    expect(docConfig.headingSelectors).toBe('h2, h3, h4');
+  });
+
+  it('Java → multi-html-toc with chapterPattern as RegExp', () => {
+    const source: DocSource = {
+      name: 'java',
+      displayName: 'Java',
+      doc: 'jls',
+      docDisplayName: 'The Java Language Specification (SE21)',
+      url: 'https://docs.oracle.com/javase/specs/jls/se21/html/index.html',
+      chapterPattern: '^jls-\\d+\\.html$',
+      sourcePolicy: 'excerpt_only',
+      notes: 'Oracle著作権のためexcerpt_only',
+    };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.fetchStrategy).toBe('multi-html-toc');
+    expect(docConfig.indexUrl).toBe('https://docs.oracle.com/javase/specs/jls/se21/html/index.html');
+    expect(docConfig.chapterPattern).toBeInstanceOf(RegExp);
+    expect(docConfig.chapterPattern!.test('jls-4.html')).toBe(true);
+    expect(docConfig.chapterPattern!.test('index.html')).toBe(false);
+    expect(docConfig.canonicalBaseUrl).toBe('https://docs.oracle.com/javase/specs/jls/se21/html');
+    expect(docConfig.notes).toBe('Oracle著作権のためexcerpt_only');
+  });
+
+  it('Rust → github-markdown with manifest', () => {
+    const source: DocSource = {
+      name: 'rust',
+      displayName: 'Rust',
+      doc: 'rust-reference',
+      docDisplayName: 'The Rust Reference',
+      github: 'rust-lang/reference',
+      path: 'src',
+      manifestFile: 'SUMMARY.md',
+      canonicalBaseUrl: 'https://doc.rust-lang.org/reference',
+    };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.fetchStrategy).toBe('github-markdown');
+    expect(docConfig.githubOwner).toBe('rust-lang');
+    expect(docConfig.githubRepo).toBe('reference');
+    expect(docConfig.githubPath).toBe('src');
+    expect(docConfig.manifestFile).toBe('SUMMARY.md');
+    expect(docConfig.sourcePolicy).toBe('local_fulltext_ok');
+    expect(docConfig.canonicalBaseUrl).toBe('https://doc.rust-lang.org/reference');
+  });
+
+  it('TypeScript → github-markdown without manifest', () => {
+    const source: DocSource = {
+      name: 'typescript',
+      displayName: 'TypeScript',
+      doc: 'ts-handbook',
+      docDisplayName: 'TypeScript Handbook',
+      github: 'microsoft/TypeScript-Website',
+      path: 'packages/documentation/copy/en/handbook-v2',
+      notes: 'Handbookは完全な仕様書ではない（公式明記）',
+    };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.fetchStrategy).toBe('github-markdown');
+    expect(docConfig.githubOwner).toBe('microsoft');
+    expect(docConfig.githubRepo).toBe('TypeScript-Website');
+    expect(docConfig.githubPath).toBe('packages/documentation/copy/en/handbook-v2');
+    expect(docConfig.sourcePolicy).toBe('local_fulltext_ok');
+    expect(docConfig.manifestFile).toBeUndefined();
+    expect(docConfig.notes).toBe('Handbookは完全な仕様書ではない（公式明記）');
+  });
+
+  it('Vitest → github-markdown with excludePaths and urlSuffix', () => {
+    const source: DocSource = {
+      name: 'vitest',
+      displayName: 'Vitest',
+      doc: 'vitest-docs',
+      docDisplayName: 'Vitest Documentation',
+      github: 'vitest-dev/vitest',
+      path: 'docs',
+      excludePaths: ['.vitepress', 'team', 'public'],
+      canonicalBaseUrl: 'https://vitest.dev',
+      urlSuffix: '',
+    };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.fetchStrategy).toBe('github-markdown');
+    expect(docConfig.githubOwner).toBe('vitest-dev');
+    expect(docConfig.githubRepo).toBe('vitest');
+    expect(docConfig.githubPath).toBe('docs');
+    expect(docConfig.excludePaths).toEqual(['.vitepress', 'team', 'public']);
+    expect(docConfig.canonicalBaseUrl).toBe('https://vitest.dev');
+    expect(docConfig.urlSuffix).toBe('');
+    expect(docConfig.sourcePolicy).toBe('local_fulltext_ok');
+  });
+});
+
+// ========================================
+// Default values
+// ========================================
+
+describe('default values', () => {
+  it('doc defaults to name + "-docs"', () => {
+    const source: DocSource = { name: 'mylib', displayName: 'MyLib', url: 'https://example.com/docs' };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.doc).toBe('mylib-docs');
+  });
+
+  it('sourcePolicy defaults to excerpt_only for url-based', () => {
+    const source: DocSource = { name: 'test', displayName: 'Test', url: 'https://example.com/spec' };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.sourcePolicy).toBe('excerpt_only');
+  });
+
+  it('sourcePolicy defaults to local_fulltext_ok for github-based', () => {
+    const source: DocSource = { name: 'test', displayName: 'Test', github: 'owner/repo' };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.sourcePolicy).toBe('local_fulltext_ok');
+  });
+
+  it('headingSelectors defaults to "h2, h3, h4"', () => {
+    const source: DocSource = { name: 'test', displayName: 'Test', url: 'https://example.com/spec' };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.headingSelectors).toBe('h2, h3, h4');
+  });
+
+  it('githubPath defaults to empty string', () => {
+    const source: DocSource = { name: 'test', displayName: 'Test', github: 'owner/repo' };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.githubPath).toBe('');
+  });
+
+  it('canonicalBaseUrl defaults to url for single-html', () => {
+    const source: DocSource = { name: 'test', displayName: 'Test', url: 'https://example.com/spec' };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.canonicalBaseUrl).toBe('https://example.com/spec');
+  });
+
+  it('canonicalBaseUrl auto-derives directory for multi-html-toc', () => {
+    const source: DocSource = {
+      name: 'test',
+      displayName: 'Test',
+      url: 'https://example.com/docs/v1/index.html',
+      chapterPattern: '^ch\\d+\\.html$',
+    };
+    const { docConfig } = resolveDocSource(source);
+    expect(docConfig.canonicalBaseUrl).toBe('https://example.com/docs/v1');
+  });
+});
+
+// ========================================
+// Zod validation
+// ========================================
+
+describe('DocSourceSchema validation', () => {
+  it('accepts valid github source', () => {
+    const result = DocSourceSchema.safeParse({
+      name: 'test', displayName: 'Test', github: 'owner/repo',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid url source', () => {
+    const result = DocSourceSchema.safeParse({
+      name: 'test', displayName: 'Test', url: 'https://example.com/spec',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects when neither url nor github', () => {
+    const result = DocSourceSchema.safeParse({
+      name: 'test', displayName: 'Test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects when both url and github', () => {
+    const result = DocSourceSchema.safeParse({
+      name: 'test', displayName: 'Test',
+      url: 'https://example.com', github: 'owner/repo',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid github format', () => {
+    const result = DocSourceSchema.safeParse({
+      name: 'test', displayName: 'Test', github: 'no-slash',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid regex in chapterPattern', () => {
+    const result = DocSourceSchema.safeParse({
+      name: 'test', displayName: 'Test',
+      url: 'https://example.com/spec',
+      chapterPattern: '[invalid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty name', () => {
+    const result = DocSourceSchema.safeParse({
+      name: '', displayName: 'Test', url: 'https://example.com',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ========================================
+// groupByLanguage
+// ========================================
+
+describe('groupByLanguage', () => {
+  it('groups multiple docs under same language', () => {
+    const sources: DocSource[] = [
+      { name: 'go', displayName: 'Go', url: 'https://go.dev/spec', doc: 'go-spec' },
+      { name: 'go', displayName: 'Go', url: 'https://go.dev/blog', doc: 'go-blog' },
+    ];
+    const resolved = sources.map(s => resolveDocSource(s));
+    const configs = groupByLanguage(resolved, sources);
+    expect(configs).toHaveLength(1);
+    expect(configs[0].language).toBe('go');
+    expect(configs[0].docs).toHaveLength(2);
+  });
+
+  it('keeps different languages separate', () => {
+    const sources: DocSource[] = [
+      { name: 'go', displayName: 'Go', url: 'https://go.dev/spec' },
+      { name: 'rust', displayName: 'Rust', github: 'rust-lang/reference' },
+    ];
+    const resolved = sources.map(s => resolveDocSource(s));
+    const configs = groupByLanguage(resolved, sources);
+    expect(configs).toHaveLength(2);
+  });
+});

--- a/tests/source-loader.test.ts
+++ b/tests/source-loader.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { loadSources } from '../src/config/source-loader.js';
+
+const TMP_DIR = resolve(import.meta.dirname, '../.tmp-test-sources');
+
+function writeTmpJson(filename: string, data: unknown): string {
+  mkdirSync(TMP_DIR, { recursive: true });
+  const path = resolve(TMP_DIR, filename);
+  writeFileSync(path, JSON.stringify(data, null, 2));
+  return path;
+}
+
+function cleanup() {
+  rmSync(TMP_DIR, { recursive: true, force: true });
+}
+
+describe('loadSources', () => {
+  it('loads the real data/sources.json and returns 5 languages', () => {
+    const configs = loadSources();
+    expect(configs).toHaveLength(5);
+    const names = configs.map(c => c.language).sort();
+    expect(names).toEqual(['go', 'java', 'rust', 'typescript', 'vitest']);
+  });
+
+  it('each language has correct displayName and at least 1 doc', () => {
+    const configs = loadSources();
+    for (const config of configs) {
+      expect(config.displayName).toBeTruthy();
+      expect(config.docs.length).toBeGreaterThan(0);
+      for (const doc of config.docs) {
+        expect(doc.doc).toBeTruthy();
+        expect(doc.fetchStrategy).toBeTruthy();
+        expect(doc.sourcePolicy).toBeTruthy();
+      }
+    }
+  });
+
+  it('Go config matches expected values', () => {
+    const configs = loadSources();
+    const go = configs.find(c => c.language === 'go')!;
+    expect(go.docs[0].fetchStrategy).toBe('single-html');
+    expect(go.docs[0].url).toBe('https://go.dev/ref/spec');
+    expect(go.docs[0].sourcePolicy).toBe('excerpt_only');
+  });
+
+  it('Java config has RegExp chapterPattern', () => {
+    const configs = loadSources();
+    const java = configs.find(c => c.language === 'java')!;
+    expect(java.docs[0].fetchStrategy).toBe('multi-html-toc');
+    expect(java.docs[0].chapterPattern).toBeInstanceOf(RegExp);
+    expect(java.docs[0].chapterPattern!.test('jls-4.html')).toBe(true);
+  });
+
+  it('Vitest config has excludePaths and empty urlSuffix', () => {
+    const configs = loadSources();
+    const vitest = configs.find(c => c.language === 'vitest')!;
+    expect(vitest.docs[0].excludePaths).toEqual(['.vitepress', 'team', 'public']);
+    expect(vitest.docs[0].urlSuffix).toBe('');
+  });
+});
+
+describe('loadSources error handling', () => {
+  afterEach(cleanup);
+
+  it('throws on missing file', () => {
+    expect(() => loadSources('/nonexistent/path.json')).toThrow('Failed to read sources file');
+  });
+
+  it('throws on invalid JSON', () => {
+    mkdirSync(TMP_DIR, { recursive: true });
+    const path = resolve(TMP_DIR, 'bad.json');
+    writeFileSync(path, '{ not valid json');
+    expect(() => loadSources(path)).toThrow('Invalid JSON');
+  });
+
+  it('throws on validation error (missing required fields)', () => {
+    const path = writeTmpJson('invalid.json', [{ name: 'test' }]);
+    expect(() => loadSources(path)).toThrow('Validation error');
+  });
+
+  it('throws on duplicate source names', () => {
+    const path = writeTmpJson('dupes.json', [
+      { name: 'test', displayName: 'Test', url: 'https://example.com/a' },
+      { name: 'test', displayName: 'Test2', url: 'https://example.com/b' },
+    ]);
+    expect(() => loadSources(path)).toThrow('Duplicate source name: "test"');
+  });
+
+  it('loads valid custom file', () => {
+    const path = writeTmpJson('custom.json', [
+      { name: 'mylib', displayName: 'MyLib', url: 'https://example.com/docs' },
+    ]);
+    const configs = loadSources(path);
+    expect(configs).toHaveLength(1);
+    expect(configs[0].language).toBe('mylib');
+  });
+});


### PR DESCRIPTION
## Summary

- **M6**: Vitest ドキュメント対応 + 汎用IT技術ドキュメント取り込み (再帰ディレクトリ探索, excludePaths, urlSuffix, chapterPattern汎化)
- **M7**: 外部設定ファイル (`data/sources.json`) + DocSource 統一モデル — コード変更・再ビルド不要で新ドキュメントソース追加可能

### M6 Changes
- Vitest docs ingestion via github-markdown with recursive directory traversal
- `excludePaths` for filtering out non-doc directories (.vitepress, team, public)
- `urlSuffix` for VitePress clean URLs (empty string instead of .html)
- `chapterPattern` generalization for multi-html-toc strategy

### M7 Changes
- `data/sources.json` — 5 existing sources defined in unified DocSource format
- `src/config/doc-source.ts` — DocSource type + Zod schema + `resolveDocSource()` resolver
- `src/config/source-loader.ts` — `loadSources()` reads JSON, validates, resolves to LanguageConfig[]
- `src/config/languages.ts` — replaced hardcoded LANGUAGES with lazy-load from source-loader
- Strategy auto-inference: `github` → github-markdown, `url` + `chapterPattern` → multi-html-toc, `url` only → single-html
- Full backward compatibility: public API unchanged, zero changes to consumers

### New Source Addition (post-M7)
```bash
# 1. Edit data/sources.json — add entry
# 2. No rebuild needed!
npm run ingest -- --language <name>
```

## Test plan
- [x] `npm run build` passes cleanly
- [x] 142 tests pass across 18 test files (was 112/16)
- [x] 34 new tests: doc-source resolver (24) + source-loader (10)
- [x] Existing `language-config.test.ts` and `vitest-config.test.ts` pass unchanged (regression)
- [x] All 5 existing sources resolve to identical DocConfig values

🤖 Generated with [Claude Code](https://claude.com/claude-code)